### PR TITLE
Leian/transect

### DIFF
--- a/streamwebs_frontend/streamwebs/admin.py
+++ b/streamwebs_frontend/streamwebs/admin.py
@@ -8,11 +8,15 @@ from .models import Site
 from .models import Water_Quality
 from .models import WQ_Sample
 from .models import Macroinvertebrates
+from .models import TransectZone
+from .models import RiparianTransect
 
 admin.site.register(Site)
 admin.site.register(Water_Quality)
 admin.site.register(WQ_Sample)
 admin.site.register(Macroinvertebrates)
+admin.site.register(TransectZone)
+admin.site.register(RiparianTransect)
 
 
 # The following will add a profile model's files to the user page in the

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -285,13 +285,14 @@ class Macroinvertebrates(models.Model):
         verbose_name_plural = 'Macroinvertebrates'
 
 
-class TransectZoneManager:
+class TransectZoneManager(models.Manager):
     """
     Manager for the TransectZone model.
     """
-    def create_zone(conifers=0, hardwood=0, shrubs=0, comments=''):
-        return self.create(conifers=conifers, hardwood=hardwood, shrubs=shrubs,
-                           comments=comments)
+    def create_zone(self, conifers=0, hardwoods=0, shrubs=0, comments=''):
+        info = self.create(conifers=conifers, hardwoods=hardwoods,
+                           shrubs=shrubs, comments=comments)
+        return info
 
 
 class TransectZone(models.Model):
@@ -314,17 +315,44 @@ class RipTransectManager(models.Manager):
     """
     Manager for the RiparianTransect model/datasheet.
     """
-    def create_transect(school, date_time, site, zone_1, zone_2, zone_3,
+    def create_transect(self, school, date_time, site, zone_1, zone_2, zone_3,
                         zone_4, zone_5, names='', weather='', slope=None,
                         notes=''):
-        return self.create(names=names, school=school, date_time=date_time,
-                           weather=weather, site=site, slope=slope,
-                           notes=notes, zone_1=zone_1, zone_2=zone_2,
-                           zone_3=zone_3, zone_4=zone_4, zone_5=zone_5)
+        return self.create(school=school, date_time=date_time, site=site,
+                           zone_1=zone_1, zone_2=zone_2, zone_3=zone_3,
+                           zone_4=zone_4, zone_5=zone_5, names=names,
+                           weather=weather, slope=slope, notes=notes)
 
 
 class RiparianTransect(models.Model):
+    """
+    This model corresponds to the Riparian Transect data sheet and has a one-to
+    -one relationship with its specified Site.
+    """
+    names = models.CharField(max_length=255, blank=True)
+    school = models.CharField(max_length=255)
+    date_time = models.DateTimeField(default=timezone.now)
+    weather = models.CharField(max_length=255, blank=True)
+    site = models.ForeignKey(Site, null=True, on_delete=models.CASCADE)
+    slope = models.DecimalField(blank=True, null=True, max_digits=5,
+                                decimal_places=3)
+    notes = models.TextField(blank=True)
+
+    zone_1 = models.ForeignKey(TransectZone, on_delete=models.CASCADE,
+                               related_name='zone_1', null=True)
+    zone_2 = models.ForeignKey(TransectZone, on_delete=models.CASCADE,
+                               related_name='zone_2', null=True)
+    zone_3 = models.ForeignKey(TransectZone, on_delete=models.CASCADE,
+                               related_name='zone_3', null=True)
+    zone_4 = models.ForeignKey(TransectZone, on_delete=models.CASCADE,
+                               related_name='zone_4', null=True)
+    zone_5 = models.ForeignKey(TransectZone, on_delete=models.CASCADE,
+                               related_name='zone_5', null=True)
+
     transects = RipTransectManager()
+
+    def __str__(self):
+        return self.site.site_name
 
     class Meta:
         verbose_name = 'Riparian Transect'

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -316,12 +316,12 @@ class RipTransectManager(models.Manager):
     Manager for the RiparianTransect model/datasheet.
     """
     def create_transect(self, school, date_time, site, zone_1, zone_2, zone_3,
-                        zone_4, zone_5, names='', weather='', slope=None,
+                        zone_4, zone_5, weather='', slope=None,
                         notes=''):
         return self.create(school=school, date_time=date_time, site=site,
                            zone_1=zone_1, zone_2=zone_2, zone_3=zone_3,
-                           zone_4=zone_4, zone_5=zone_5, names=names,
-                           weather=weather, slope=slope, notes=notes)
+                           zone_4=zone_4, zone_5=zone_5, weather=weather,
+                           slope=slope, notes=notes)
 
 
 class RiparianTransect(models.Model):
@@ -329,7 +329,6 @@ class RiparianTransect(models.Model):
     This model corresponds to the Riparian Transect data sheet and has a one-to
     -one relationship with its specified Site.
     """
-    names = models.CharField(max_length=255, blank=True)
     school = models.CharField(max_length=255)
     date_time = models.DateTimeField(default=timezone.now)
     weather = models.CharField(max_length=255, blank=True)

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -283,3 +283,49 @@ class Macroinvertebrates(models.Model):
     class Meta:
         verbose_name = 'Macroinvertebrate'
         verbose_name_plural = 'Macroinvertebrates'
+
+
+class TransectZoneManager:
+    """
+    Manager for the TransectZone model.
+    """
+    def create_zone(conifers=0, hardwood=0, shrubs=0, comments=''):
+        return self.create(conifers=conifers, hardwood=hardwood, shrubs=shrubs,
+                           comments=comments)
+
+
+class TransectZone(models.Model):
+    """
+    Each Riparian Transect datasheet requires five zones.
+    """
+    conifers = models.PositiveSmallIntegerField(default=0)
+    hardwoods = models.PositiveSmallIntegerField(default=0)
+    shrubs = models.PositiveSmallIntegerField(default=0)
+    comments = models.TextField(blank=True)
+
+    zones = TransectZoneManager()
+
+    class Meta:
+        verbose_name = 'Zone'
+        verbose_name_plural = 'Zones'
+
+
+class RipTransectManager(models.Manager):
+    """
+    Manager for the RiparianTransect model/datasheet.
+    """
+    def create_transect(school, date_time, site, zone_1, zone_2, zone_3,
+                        zone_4, zone_5, names='', weather='', slope=None,
+                        notes=''):
+        return self.create(names=names, school=school, date_time=date_time,
+                           weather=weather, site=site, slope=slope,
+                           notes=notes, zone_1=zone_1, zone_2=zone_2,
+                           zone_3=zone_3, zone_4=zone_4, zone_5=zone_5)
+
+
+class RiparianTransect(models.Model):
+    transects = RipTransectManager()
+
+    class Meta:
+        verbose_name = 'Riparian Transect'
+        verbose_name_plural = 'Riparian Transects'

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -306,6 +306,9 @@ class TransectZone(models.Model):
 
     zones = TransectZoneManager()
 
+    def __str__(self):
+        return str(self.id)
+
     class Meta:
         verbose_name = 'Zone'
         verbose_name_plural = 'Zones'

--- a/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
@@ -16,7 +16,6 @@ class RiparianTransectTestCase(TestCase):
             'site': models.ForeignKey,
             'site_id': models.ForeignKey,
             'slope': models.DecimalField,
-            'notes': models.TextField,
             'id': models.AutoField,
             'zone_1': models.ForeignKey,
             'zone_2': models.ForeignKey,
@@ -33,7 +32,6 @@ class RiparianTransectTestCase(TestCase):
         }
 
         self.optional_fields = {
-            'names': models.CharField,
             'weather': models.CharField,
             'slope': models.DecimalField,
             'notes': models.TextField,
@@ -109,8 +107,7 @@ class RiparianTransectTestCase(TestCase):
         zone_5 = TransectZone.zones.create_zone(5, 5, 5, 'Comments on zone 5')
         transect = RiparianTransect.transects.create_transect(
             'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
-            zone_4, zone_5, 'Katie and Sally', 'Cloudy, no meatballs', 1.11,
-            'Notes on transect')
+            zone_4, zone_5, 'Cloudy, no meatballs', 1.11, 'Notes on transect')
 
         # Required
         self.assertEqual(transect.school, 'School of Cool')
@@ -118,7 +115,6 @@ class RiparianTransectTestCase(TestCase):
         self.assertEqual(transect.site.site_name, 'test site')
 
         # Optional
-        self.assertEqual(transect.names, 'Katie and Sally')
         self.assertEqual(transect.weather, 'Cloudy, no meatballs')
         self.assertEqual(transect.slope, 1.11)
         self.assertEqual(transect.notes, 'Notes on transect')

--- a/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
@@ -1,12 +1,11 @@
 from django.test import TestCase
 from django.contrib.gis.db import models
-from django.apps import apps
 from itertools import chain
 
 from streamwebs.models import RiparianTransect, TransectZone, Site
 
 
-class RiparianTransectTestCase(self):
+class RiparianTransectTestCase(TestCase):
 
     def setUp(self):
         self.expected_fields = {
@@ -24,7 +23,7 @@ class RiparianTransectTestCase(self):
             'zone_3': models.ForeignKey,
             'zone_4': models.ForeignKey,
             'zone_5': models.ForeignKey,
-    
+
             # Corresponding zone id
             'zone_1_id': models.ForeignKey,
             'zone_2_id': models.ForeignKey,
@@ -48,7 +47,7 @@ class RiparianTransectTestCase(self):
     def test_no_extra_fields(self):
         fields = list(set(chain.from_iterable(
             (field.name, field.attname) if hasattr(field, 'attname') else
-            (field.name,) for field in TransectZone._meta.get_fields()
+            (field.name,) for field in RiparianTransect._meta.get_fields()
             if not (field.many_to_one and field.related_model is None)
         )))
         self.assertEqual(sorted(fields), sorted(self.expected_fields.keys()))
@@ -64,16 +63,11 @@ class RiparianTransectTestCase(self):
         """
         site = Site.objects.create_site('test site', 'test site type',
                                         'test_site_slug')
-        zone_1 = TransectZone.zones.create_zone(1, 1, 1,
-                                                'Comments on test site')
-        zone_2 = TransectZone.zones.create_zone(2, 2, 2,
-                                                'Comments on test site')
-        zone_3 = TransectZone.zones.create_zone(3, 3, 3,
-                                                'Comments on test site')
-        zone_4 = TransectZone.zones.create_zone(4, 4, 4,
-                                                'Comments on test site')
-        zone_5 = TransectZone.zones.create_zone(5, 5, 5,
-                                                'Comments on test site')
+        zone_1 = TransectZone.zones.create_zone(1, 1, 1, 'Comments on zone 1')
+        zone_2 = TransectZone.zones.create_zone(2, 2, 2, 'Comments on zone 2')
+        zone_3 = TransectZone.zones.create_zone(3, 3, 3, 'Comments on zone 3')
+        zone_4 = TransectZone.zones.create_zone(4, 4, 4, 'Comments on zone 4')
+        zone_5 = TransectZone.zones.create_zone(5, 5, 5, 'Comments on zone 5')
         transect = RiparianTransect.transects.create_transect(
             'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
             zone_4, zone_5)
@@ -82,7 +76,7 @@ class RiparianTransectTestCase(self):
         self.assertEqual(transect.site.site_type, 'test site type')
         self.assertEqual(transect.site.site_slug, 'test_site_slug')
 
-    def test_datasheet_creation_req_fields:
+    def test_datasheet_creation_req_fields(self):
         site = Site.objects.create_site('test site', 'test site type',
                                         'test_site_slug')
         zone_1 = TransectZone.zones.create_zone(1, 1, 1, 'Comments on zone 1')
@@ -105,7 +99,7 @@ class RiparianTransectTestCase(self):
         self.assertEqual(transect.slope, None)
         self.assertEqual(transect.notes, '')
 
-    def test_datasheet_creation_opt_fields:
+    def test_datasheet_creation_opt_fields(self):
         site = Site.objects.create_site('test site', 'test site type',
                                         'test_site_slug')
         zone_1 = TransectZone.zones.create_zone(1, 1, 1, 'Comments on zone 1')
@@ -114,9 +108,9 @@ class RiparianTransectTestCase(self):
         zone_4 = TransectZone.zones.create_zone(4, 4, 4, 'Comments on zone 4')
         zone_5 = TransectZone.zones.create_zone(5, 5, 5, 'Comments on zone 5')
         transect = RiparianTransect.transects.create_transect(
-            'Katie and Sally', 'School of Cool', '2016-07-11 14:09', 'Cloudy, 
-            no meatballs', site, 1.11, 'Notes on transect', zone_1, zone_2,
-            zone_3, zone_4, zone_5)
+            'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
+            zone_4, zone_5, 'Katie and Sally', 'Cloudy, no meatballs', 1.11,
+            'Notes on transect')
 
         # Required
         self.assertEqual(transect.school, 'School of Cool')
@@ -126,10 +120,10 @@ class RiparianTransectTestCase(self):
         # Optional
         self.assertEqual(transect.names, 'Katie and Sally')
         self.assertEqual(transect.weather, 'Cloudy, no meatballs')
-        self.assertEqual(transect.slope, None)
+        self.assertEqual(transect.slope, 1.11)
         self.assertEqual(transect.notes, 'Notes on transect')
 
-    def test_datasheet_SetZonesInfo:
+    def test_datasheet_SetZonesInfo(self):
         site = Site.objects.create_site('test site', 'test site type',
                                         'test_site_slug')
         zone_1 = TransectZone.zones.create_zone(1, 2, 3, 'Comments on zone 1')
@@ -140,7 +134,7 @@ class RiparianTransectTestCase(self):
         transect = RiparianTransect.transects.create_transect(
             'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
             zone_4, zone_5)
-    
+
         self.assertEqual(transect.zone_1.conifers, 1)
         self.assertEqual(transect.zone_1.hardwoods, 2)
         self.assertEqual(transect.zone_1.shrubs, 3)

--- a/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
@@ -1,0 +1,167 @@
+from django.test import TestCase
+from django.contrib.gis.db import models
+from django.apps import apps
+from itertools import chain
+
+from streamwebs.models import RiparianTransect, TransectZone, Site
+
+
+class RiparianTransectTestCase(self):
+
+    def setUp(self):
+        self.expected_fields = {
+            'names': models.CharField,
+            'school': models.CharField,
+            'date_time': models.DateTimeField,
+            'weather': models.CharField,
+            'site': models.ForeignKey,
+            'site_id': models.ForeignKey,
+            'slope': models.DecimalField,
+            'notes': models.TextField,
+            'id': models.AutoField,
+            'zone_1': models.ForeignKey,
+            'zone_2': models.ForeignKey,
+            'zone_3': models.ForeignKey,
+            'zone_4': models.ForeignKey,
+            'zone_5': models.ForeignKey,
+    
+            # Corresponding zone id
+            'zone_1_id': models.ForeignKey,
+            'zone_2_id': models.ForeignKey,
+            'zone_3_id': models.ForeignKey,
+            'zone_4_id': models.ForeignKey,
+            'zone_5_id': models.ForeignKey,
+        }
+
+        self.optional_fields = {
+            'names': models.CharField,
+            'weather': models.CharField,
+            'slope': models.DecimalField,
+            'notes': models.TextField,
+        }
+
+    def test_fields_exist(self):
+        for field, field_type in self.expected_fields.items():
+            self.assertEqual(field_type,
+                             type(RiparianTransect._meta.get_field(field)))
+
+    def test_no_extra_fields(self):
+        fields = list(set(chain.from_iterable(
+            (field.name, field.attname) if hasattr(field, 'attname') else
+            (field.name,) for field in TransectZone._meta.get_fields()
+            if not (field.many_to_one and field.related_model is None)
+        )))
+        self.assertEqual(sorted(fields), sorted(self.expected_fields.keys()))
+
+    def test_optional_fields(self):
+        for field in self.optional_fields:
+            self.assertEqual(RiparianTransect._meta.get_field(field).blank,
+                             True)
+
+    def test_Transect_ManyToOneSite(self):
+        """
+        A datasheet should correctly correspond to a single site.
+        """
+        site = Site.objects.create_site('test site', 'test site type',
+                                        'test_site_slug')
+        zone_1 = TransectZone.zones.create_zone(1, 1, 1,
+                                                'Comments on test site')
+        zone_2 = TransectZone.zones.create_zone(2, 2, 2,
+                                                'Comments on test site')
+        zone_3 = TransectZone.zones.create_zone(3, 3, 3,
+                                                'Comments on test site')
+        zone_4 = TransectZone.zones.create_zone(4, 4, 4,
+                                                'Comments on test site')
+        zone_5 = TransectZone.zones.create_zone(5, 5, 5,
+                                                'Comments on test site')
+        transect = RiparianTransect.transects.create_transect(
+            'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
+            zone_4, zone_5)
+
+        self.assertEqual(transect.site.site_name, 'test site')
+        self.assertEqual(transect.site.site_type, 'test site type')
+        self.assertEqual(transect.site.site_slug, 'test_site_slug')
+
+    def test_datasheet_creation_req_fields:
+        site = Site.objects.create_site('test site', 'test site type',
+                                        'test_site_slug')
+        zone_1 = TransectZone.zones.create_zone(1, 1, 1, 'Comments on zone 1')
+        zone_2 = TransectZone.zones.create_zone(2, 2, 2, 'Comments on zone 2')
+        zone_3 = TransectZone.zones.create_zone(3, 3, 3, 'Comments on zone 3')
+        zone_4 = TransectZone.zones.create_zone(4, 4, 4, 'Comments on zone 4')
+        zone_5 = TransectZone.zones.create_zone(5, 5, 5, 'Comments on zone 5')
+        transect = RiparianTransect.transects.create_transect(
+            'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
+            zone_4, zone_5)
+
+        # Required
+        self.assertEqual(transect.school, 'School of Cool')
+        self.assertEqual(transect.date_time, '2016-07-11 14:09')
+        self.assertEqual(transect.site.site_name, 'test site')
+
+        # Optional
+        self.assertEqual(transect.names, '')
+        self.assertEqual(transect.weather, '')
+        self.assertEqual(transect.slope, None)
+        self.assertEqual(transect.notes, '')
+
+    def test_datasheet_creation_opt_fields:
+        site = Site.objects.create_site('test site', 'test site type',
+                                        'test_site_slug')
+        zone_1 = TransectZone.zones.create_zone(1, 1, 1, 'Comments on zone 1')
+        zone_2 = TransectZone.zones.create_zone(2, 2, 2, 'Comments on zone 2')
+        zone_3 = TransectZone.zones.create_zone(3, 3, 3, 'Comments on zone 3')
+        zone_4 = TransectZone.zones.create_zone(4, 4, 4, 'Comments on zone 4')
+        zone_5 = TransectZone.zones.create_zone(5, 5, 5, 'Comments on zone 5')
+        transect = RiparianTransect.transects.create_transect(
+            'Katie and Sally', 'School of Cool', '2016-07-11 14:09', 'Cloudy, 
+            no meatballs', site, 1.11, 'Notes on transect', zone_1, zone_2,
+            zone_3, zone_4, zone_5)
+
+        # Required
+        self.assertEqual(transect.school, 'School of Cool')
+        self.assertEqual(transect.date_time, '2016-07-11 14:09')
+        self.assertEqual(transect.site.site_name, 'test site')
+
+        # Optional
+        self.assertEqual(transect.names, 'Katie and Sally')
+        self.assertEqual(transect.weather, 'Cloudy, no meatballs')
+        self.assertEqual(transect.slope, None)
+        self.assertEqual(transect.notes, 'Notes on transect')
+
+    def test_datasheet_SetZonesInfo:
+        site = Site.objects.create_site('test site', 'test site type',
+                                        'test_site_slug')
+        zone_1 = TransectZone.zones.create_zone(1, 2, 3, 'Comments on zone 1')
+        zone_2 = TransectZone.zones.create_zone(2, 3, 1, 'Comments on zone 2')
+        zone_3 = TransectZone.zones.create_zone(3, 2, 1, 'Comments on zone 3')
+        zone_4 = TransectZone.zones.create_zone(4, 5, 6, 'Comments on zone 4')
+        zone_5 = TransectZone.zones.create_zone(5, 2, 3, 'Comments on zone 5')
+        transect = RiparianTransect.transects.create_transect(
+            'School of Cool', '2016-07-11 14:09', site, zone_1, zone_2, zone_3,
+            zone_4, zone_5)
+    
+        self.assertEqual(transect.zone_1.conifers, 1)
+        self.assertEqual(transect.zone_1.hardwoods, 2)
+        self.assertEqual(transect.zone_1.shrubs, 3)
+        self.assertEqual(transect.zone_1.comments, 'Comments on zone 1')
+
+        self.assertEqual(transect.zone_2.conifers, 2)
+        self.assertEqual(transect.zone_2.hardwoods, 3)
+        self.assertEqual(transect.zone_2.shrubs, 1)
+        self.assertEqual(transect.zone_2.comments, 'Comments on zone 2')
+
+        self.assertEqual(transect.zone_3.conifers, 3)
+        self.assertEqual(transect.zone_3.hardwoods, 2)
+        self.assertEqual(transect.zone_3.shrubs, 1)
+        self.assertEqual(transect.zone_3.comments, 'Comments on zone 3')
+
+        self.assertEqual(transect.zone_4.conifers, 4)
+        self.assertEqual(transect.zone_4.hardwoods, 5)
+        self.assertEqual(transect.zone_4.shrubs, 6)
+        self.assertEqual(transect.zone_4.comments, 'Comments on zone 4')
+
+        self.assertEqual(transect.zone_5.conifers, 5)
+        self.assertEqual(transect.zone_5.hardwoods, 2)
+        self.assertEqual(transect.zone_5.shrubs, 3)
+        self.assertEqual(transect.zone_5.comments, 'Comments on zone 5')

--- a/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
@@ -9,13 +9,13 @@ class RiparianTransectTestCase(TestCase):
 
     def setUp(self):
         self.expected_fields = {
-            'names': models.CharField,
             'school': models.CharField,
             'date_time': models.DateTimeField,
             'weather': models.CharField,
             'site': models.ForeignKey,
             'site_id': models.ForeignKey,
             'slope': models.DecimalField,
+            'notes': models.TextField,
             'id': models.AutoField,
             'zone_1': models.ForeignKey,
             'zone_2': models.ForeignKey,
@@ -92,7 +92,6 @@ class RiparianTransectTestCase(TestCase):
         self.assertEqual(transect.site.site_name, 'test site')
 
         # Optional
-        self.assertEqual(transect.names, '')
         self.assertEqual(transect.weather, '')
         self.assertEqual(transect.slope, None)
         self.assertEqual(transect.notes, '')

--- a/streamwebs_frontend/streamwebs/tests/models/test_site_model.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_site_model.py
@@ -21,7 +21,8 @@ class SiteTestCase(TestCase):
 
             # Datasheets
             'water_quality': models.ManyToOneRel,
-            'macroinvertebrates': models.ManyToOneRel
+            'macroinvertebrates': models.ManyToOneRel,
+            'ripariantransect': models.ManyToOneRel,
         }
 
         self.optional_fields = {

--- a/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from django.contrib.gis.db import models
+from django.apps import apps
+from itertools import chain
+
+from streamwebs.models import TransectZone
+
+class TransectZoneTestCase(TestCase):
+
+    def setUp(self):
+        self.expected_fields = {
+            'conifers': models.PositiveSmallIntegerField,
+            'hardwoods': models.PositiveSmallIntegerField,
+            'shrubs': models.PositiveSmallIntegerField,
+            'comments': models.CharField,
+            'id': models.AutoField,
+
+        # Foreign key relation
+            'zone_1': models.ManyToOneRel,
+            'zone_2': models.ManyToOneRel,
+            'zone_3': models.ManyToOneRel,
+            'zone_4': models.ManyToOneRel,
+            'zone_5': models.ManyToOneRel,
+        }
+
+    def test_fields_exist(self):
+        for field, field_type in self.expected_fields.items():
+            self.assertEqual(field_type,
+                             type(TransectZone._meta.get_field(field)))
+
+    def test_no_extra_fields(self):
+        fields = list(set(chain.from_iterable(
+            (field.name, field.attname) if hasattr(field, 'attname') else
+            (field.name,) for field in TransectZone._meta.get_fields()
+            if not (field.many_to_one and field.related_model is None)
+        )))
+        self.assertEqual(sorted(fields), sorted(self.expected_fields.keys()))

--- a/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
@@ -5,6 +5,7 @@ from itertools import chain
 
 from streamwebs.models import TransectZone
 
+
 class TransectZoneTestCase(TestCase):
 
     def setUp(self):

--- a/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from django.contrib.gis.db import models
-from django.apps import apps
 from itertools import chain
 
 from streamwebs.models import TransectZone
@@ -13,10 +12,10 @@ class TransectZoneTestCase(TestCase):
             'conifers': models.PositiveSmallIntegerField,
             'hardwoods': models.PositiveSmallIntegerField,
             'shrubs': models.PositiveSmallIntegerField,
-            'comments': models.CharField,
+            'comments': models.TextField,
             'id': models.AutoField,
 
-        # Foreign key relation
+            # Foreign key relation
             'zone_1': models.ManyToOneRel,
             'zone_2': models.ManyToOneRel,
             'zone_3': models.ManyToOneRel,

--- a/streamwebs_frontend/streamwebs_frontend/settings.py
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py
@@ -122,7 +122,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Satisfies issue #65. Ignores the "graph" part of the original printable data sheet since it's redundant and something that we can generate for the user based on their input. 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Tests the riparian transect zone model
- [X] Implements the riparian transect zone model
- [X] Tests the riparian transect data sheet model
- [x] Implements the riparian transect data sheet model

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->


1. Run ``docker-compose run web bash``
2. ``cd`` into ``streamwebs_frontend``
3. Run ``python manage.py makemigrations`` to bring your database up to speed
4. If there are migrations, ``python manage.py migrate`` (or just migrate anyway)
5. Run ``python manage.py test streamwebs/tests/models`` or ``python manage.py test streamwebs/tests/*`` 

## Expected output.
Tests should pass with this output:
```
[root@e12d9ef50b38 streamwebs_frontend]# python manage.py test streamwebs/tests/models/
Creating test database for alias 'default'...
/usr/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1453: RuntimeWarning: DateTimeField RiparianTransect.date_time received a naive datetime (2016-07-11 14:09:00) while time zone support is active.
  RuntimeWarning)

.................................
----------------------------------------------------------------------
Ran 33 tests in 0.515s

OK
Destroying test database for alias 'default'...
```
Anyone know how to get rid of the warning? It's complaining about the static date time value I'm passing to RiparianTransect's date_time field in my tests (because the default=timezone.now?) @athai did not encounter this warning in Macroinvertebrates because in her tests she just passed in timezone.now. 

@subnomo @athai @alxngyn @Kennric 