### PR TITLE
RAS's routing and view.py

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/ras_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/ras_edit.html
@@ -1,0 +1,1 @@
+this is RAS edit

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/ras_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/ras_view.html
@@ -1,0 +1,1 @@
+this is RAS view

--- a/streamwebs_frontend/streamwebs/urls.py
+++ b/streamwebs_frontend/streamwebs/urls.py
@@ -1,8 +1,15 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 from . import views
 
 app_name = 'streamwebs'
+
+# Riparrian and Aquatic Survey:
+RAS_patterns = [
+    url(r'^(?P<data_id>\d+)', views.RAS, name='water_quality'),
+    url(r'^edit', views.RAS_edit, name='water_quality_edit'),
+]
+
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^sites$', views.sites, name='sites'),
@@ -11,6 +18,8 @@ urlpatterns = [
         views.water_quality, name='water_quality'),
     url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/water/edit',
         views.water_quality_edit, name='water_quality_edit'),
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/ras/',
+        include(RAS_patterns), name='ras'),
     url(r'^register/$', views.register, name='register'),
     url(r'^login/$', views.user_login, name='login'),
     url(r'^logout/$', views.user_logout, name='logout')

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -243,3 +243,21 @@ def water_quality_edit(request, site_slug):
     return render(request, 'streamwebs/datasheets/water_quality_edit.html', {
         'site': site
     })
+
+
+def RAS(request, site_slug, data_id):
+    site = {
+        'data': 'data mc dataface'
+    }
+    return render(request, 'streamwebs/datasheets/ras_view.html', {
+        'site': site
+    })
+
+
+def RAS_edit(request, site_slug):
+    site = {
+        'data': 'should probz go here'
+    }
+    return render(request, 'streamwebs/datasheets/ras_edit.html', {
+        'site': site
+    })


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #68 
This is an initial PR for setting up the Riparrian and Aquatic Survey's url routing.
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Changes to urls.py to take `site/<site slug>/ras
- [X] Implemented RAS view and edit render functions in views.py
- [X] Blank htmls in `templates/streamwebs/datasheets/`
- [ ] Flesh out views.py to serve data
- [ ] still need POST handling for incoming data
- [ ] tests
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. `sudo docker-compose up`
2. In a browser or curl, goto 
   - [http://localhost:8000/streamwebs/site/test1/ras/1](http://localhost:8000/streamwebs/site/test1/ras/1) and  
   - [http://localhost:8000/streamwebs/site/test1/ras/edit](http://localhost:8000/streamwebs/site/test1/ras/edit)
3. Look at results
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
this PR handles URL routing...

http://localhost:8000/streamwebs/site/test1/ras/1
result -> 'this is RAS view'

http://localhost:8000/streamwebs/site/test1/ras/edit
result -> 'this is RAS edit'
```

@osuosl/devs 
