### PR TITLE
Leian/re recaptcha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psycopg2
 requests
 wsgiref
 flake8
+django-recaptcha

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -5,7 +5,7 @@ from streamwebs.models import Canopy_Cover, CC_Cardinal
 from django.contrib.auth.models import User
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-
+from captcha.fields import ReCaptchaField
 
 class UserForm(forms.ModelForm):
     password = forms.CharField(widget=forms.PasswordInput()) \
@@ -32,6 +32,8 @@ class UserForm(forms.ModelForm):
 
 
 class UserProfileForm(forms.ModelForm):
+    captcha = ReCaptchaField()
+
     class Meta:
         model = UserProfile
         fields = ('school', 'birthdate')

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -7,12 +7,14 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 from captcha.fields import ReCaptchaField
 
+
 class UserForm(forms.ModelForm):
     password = forms.CharField(widget=forms.PasswordInput()) \
                 .label = _('Password')
     password_check = forms.CharField(
         widget=forms.PasswordInput(),
         label='Repeat your password')
+    email = forms.CharField(required=True)
 
     class Meta:
         model = User

--- a/streamwebs_frontend/streamwebs/tests/forms/test_user_reg_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_user_reg_form.py
@@ -33,5 +33,7 @@ class UserProfileFormTestCase(TestCase):
 
     def test_UserProfileForm_fields_exist(self):
         user_prof_form = UserProfileForm()
-        self.assertEqual(
-            set(user_prof_form.Meta.fields), set(self.expected_fields))
+        self.assertEqual(set(user_prof_form.Meta.fields),
+                         set(self.expected_fields))
+        self.assertEqual(str(type(user_prof_form.base_fields['captcha'])),
+                         "<class 'captcha.fields.ReCaptchaField'>")

--- a/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
@@ -30,6 +30,8 @@ class RegistrateTestCase(TestCase):
                              'This field is required.')
         self.assertFormError(response1, 'user_form', 'password',
                              'This field is required.')
+        self.assertFormError(response1, 'user_form', 'password_check',
+                             'This field is required.')
         self.assertFormError(response1, 'user_form', 'email',
                              'This field is required.')
         self.assertFormError(response1, 'profile_form', 'birthdate',
@@ -51,6 +53,7 @@ class RegistrateTestCase(TestCase):
                 'password': 'johniscool',
                 'first_name': 'John',
                 'last_name': 'Johnson',
+                'password_check': 'johniscool',
                 'school': 'a',
                 'birthdate': '1995-11-10',
                 'g-recaptcha-response': 'NOPE'
@@ -72,7 +75,8 @@ class RegistrateTestCase(TestCase):
                 'last_name': 'Johnson',
                 'password_check': 'johniscool',
                 'school': 'a',
-                'birthdate': '1995-11-10'
+                'birthdate': '1995-11-10',
+                'g-recaptcha-response': 'PASSED'
             }
         )
         self.assertEqual(user_form_response.status_code, 200)
@@ -88,7 +92,8 @@ class RegistrateTestCase(TestCase):
                 'last_name': 'Johnson',
                 'password_check': 'johnisnotcool',
                 'school': 'a',
-                'birthdate': '1995-11-10'
+                'birthdate': '1995-11-10',
+                'g-recaptcha-response': 'PASSED'
             }
         )
         self.assertFormError(
@@ -98,26 +103,6 @@ class RegistrateTestCase(TestCase):
             'Passwords do not match'
         )
         self.assertFalse(bad_pw_response.context['registered'])
-        with self.settings(SCHOOL_CHOICES=(
-            ('a', 'School A'),
-            ('b', 'School B'),
-            ('c', 'School C'),
-        )):
-            user_form_response = self.client.post(
-                reverse('streamwebs:register'), {
-                    'username': 'john',
-                    'email': 'john@example.com',
-                    'password': 'johniscool',
-                    'first_name': 'John',
-                    'last_name': 'Johnson',
-                    'school': 'a',
-                    'birthdate': '1995-11-10',
-                    'g-recaptcha-response': 'PASSED'
-                }
-            )
-
-            self.assertEqual(user_form_response.status_code, 200)
-            self.assertTrue(user_form_response.context['registered'])
 
     def test_view_with_captcha_mode_false(self):
         """
@@ -134,6 +119,7 @@ class RegistrateTestCase(TestCase):
                 'password': 'johniscool',
                 'first_name': 'John',
                 'last_name': 'Johnson',
+                'password_check': 'johniscool',
                 'school': 'a',
                 'birthdate': '1995-11-10',
                 'g-recaptcha-response': 'PASSED'

--- a/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
@@ -39,6 +39,25 @@ class RegistrateTestCase(TestCase):
 
         self.assertFalse(response1.context['registered'])
 
+    def test_view_with_good_creds_bad_captcha(self):
+        """
+        When fields are filled but a bad captcha is submitted,
+        the 'user' should be unable to register.
+        """
+        response = self.client.post(
+            reverse('streamwebs:register'), {
+                'username': 'john',
+                'email': 'john@example.com',
+                'password': 'johniscool',
+                'first_name': 'John',
+                'last_name': 'Johnson',
+                'school': 'a',
+                'birthdate': '1995-11-10',
+                'g-recaptcha-response': 'NOPE'
+            }
+        )
+        self.assertFalse(response.context['registered'])
+
     def test_view_with_good_post_data(self):
         """
         When user submits a good form, they should be able to register
@@ -99,6 +118,28 @@ class RegistrateTestCase(TestCase):
 
             self.assertEqual(user_form_response.status_code, 200)
             self.assertTrue(user_form_response.context['registered'])
+
+    def test_view_with_captcha_mode_false(self):
+        """
+        Bonus test to make sure that django-recaptcha's test mode works as
+        advertised. When RECAPTCHA_TESTING is False, sending 'PASSED' for the
+        captcha field should no longer successfully validate the form, and thus
+        the user should not be able to register. This test passes (7/14/2016).
+        """
+        os.environ['RECAPTCHA_TESTING'] = 'False'
+        response = self.client.post(
+            reverse('streamwebs:register'), {
+                'username': 'john',
+                'email': 'john@example.com',
+                'password': 'johniscool',
+                'first_name': 'John',
+                'last_name': 'Johnson',
+                'school': 'a',
+                'birthdate': '1995-11-10',
+                'g-recaptcha-response': 'PASSED'
+            }
+        )
+        self.assertFalse(response.context['registered'])
 
     def tearDown(self):
         del os.environ['RECAPTCHA_TESTING']

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -37,10 +37,6 @@ RECAPTCHA_PRIVATE_KEY= '6Lep3yQTAAAAAMRW7tnIDr2NUV77CWPRJ96wmWo3'
 # Captcha type: one-click
 NOCAPTCHA = True
 
-# Test mode
-if 'test' in sys.argv:
-    os.environ['RECAPTCHA_TESTING'] = 'True'
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -15,6 +15,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 
 import os
 from django.utils.translation import ugettext_lazy as _
+import sys
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -33,7 +34,13 @@ SECRET_KEY = '9$b3ov_dw6+&_(9w89p7&_&bsxzohtsf_7k!qyn-33696w#3&h'
 RECAPTCHA_PUBLIC_KEY = '6Lep3yQTAAAAANSLTu1MzZQzFD_KNpwYlfp3tPzM'
 RECAPTCHA_PRIVATE_KEY= '6Lep3yQTAAAAAMRW7tnIDr2NUV77CWPRJ96wmWo3'
 
+# Captcha type: one-click
 NOCAPTCHA = True
+
+# Test mode
+if 'test' in sys.argv:
+    os.environ['RECAPTCHA_TESTING'] = 'True'
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -29,6 +29,11 @@ LOCALE_PATHS = [
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '9$b3ov_dw6+&_(9w89p7&_&bsxzohtsf_7k!qyn-33696w#3&h'
 
+# Google ('no-captcha') recaptcha
+RECAPTCHA_PUBLIC_KEY = '6Lep3yQTAAAAANSLTu1MzZQzFD_KNpwYlfp3tPzM'
+RECAPTCHA_PRIVATE_KEY= '6Lep3yQTAAAAAMRW7tnIDr2NUV77CWPRJ96wmWo3'
+
+NOCAPTCHA = True
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
@@ -45,6 +50,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.gis',
+    'captcha',
     'pipeline',
     'streamwebs',
 ]


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Probably fixes issue #50 and #72  ...

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Adds Google's "no-captcha recaptcha" to registration via [django-recaptcha](https://github.com/praekelt/django-recaptcha)
- [X] Tests the functionality of both the captcha and the built-in captcha testing mode
- [X] Further fleshes out registration tests (+email is now a required field)

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

To run tests:
1. Run ``docker-compose run web bash`` to open up an interactive shell
2. ``cd`` into ``streamwebs_frontend/``
3. Run ``python manage.py test streamwebs/tests/forms`` and ``python manage.py test streamwebs/tests/views`` (or ``python manage.py test streamwebs/tests/*`` to run all the tests) 

To see it in action in-browser:
1. Run ``docker-compose up``
2. Go to http://localhost:8000/streamwebs/ and click "register"

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
[root@5ec97e04c726 streamwebs_frontend]# python manage.py test streamwebs/tests/*
Creating test database for alias 'default'...
...........................<ul class="errorlist"><li>username<ul class="errorlist"><li>This field is required.</li></ul></li><li>password<ul class="errorlist"><li>This field is required.</li></ul></li><li>email<ul class="errorlist"><li>This field is required.</li></ul></li></ul> <ul class="errorlist"><li>captcha<ul class="errorlist"><li>This field is required.</li></ul></li><li>school<ul class="errorlist"><li>This field is required.</li></ul></li><li>birthdate<ul class="errorlist"><li>This field is required.</li></ul></li></ul>
. <ul class="errorlist"><li>captcha<ul class="errorlist"><li>Incorrect, please try again.</li></ul></li></ul>
. <ul class="errorlist"><li>captcha<ul class="errorlist"><li>Incorrect, please try again.</li></ul></li></ul>
...Invalid login details: notjohn, badpassword
.Invalid login details: notjohn, johnpassword
.Invalid login details: john, badpassword
.....
----------------------------------------------------------------------
Ran 39 tests in 1.273s

OK
Destroying test database for alias 'default'...
```
![captcha_reg](https://cloud.githubusercontent.com/assets/9158473/16852006/f60aa360-49ba-11e6-8e33-478d0efcb3e7.png)

### Notes.
When you run ``python manage.py test captcha`` you actually get a test failure:
```
[root@5ec97e04c726 streamwebs_frontend]# python manage.py test captcha
Creating test database for alias 'default'...
.F
======================================================================
FAIL: test_envvar_enabled (captcha.tests.TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/captcha/tests.py", line 19, in test_envvar_enabled
    self.assertTrue(form.is_valid())
AssertionError: False is not true

----------------------------------------------------------------------
Ran 2 tests in 0.001s

FAILED (failures=1)
Destroying test database for alias 'default'...
```
The test in question is can be viewed [here](https://github.com/praekelt/django-recaptcha/blob/develop/captcha/tests.py). It only tests the functionality of their RECAPTCHA_TESTING environmental variable. I put near-identical tests in ``streamwebs_frontend/streamwebs/tests/views/test_registration_view.py`` and they pass, indicating that their test mode does work. In addition, the captcha itself works exactly as expected, both in my tests and in the browser.

@Kennric @athai @alxngyn @subnomo @LyonesGamer 