### PR TITLE
cthalmann/macroValidator Added .clean() method and tests.

### DIFF
--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -291,16 +291,22 @@ class Macroinvertebrates(models.Model):
            + self.damselfly + self.dragonfly + self.scud + self.fishfly
            + self.alderfly + self.mite) * 2) != self.somewhat_sensitive_total:
                 raise ValidationError(
-                    _('%(sensitive_total)s is not the correct total'),
-                    params={'sensitive_total': self.somewhat_sensitive_total},
+                    _('%(some_sensitive)s is not the correct total'),
+                    params={'some_sensitive': self.somewhat_sensitive_total},
                 )
 
         if(self.aquatic_worm + self.blackfly + self.leech + self.midge
            + self.snail + self.mosquito_larva) != self.tolerant_total:
                 raise ValidationError(
-                    _('%(sensitive_total)s is not the correct total'),
-                    params={'sensitive_total': self.tolerant_total},
+                    _('%(tolerant_total)s is not the correct total'),
+                    params={'tolerant_total': self.tolerant_total},
                     )
+        if(self.sensitive_total + self.somewhat_sensitive_total
+           + self.tolerant_total) != self.wq_rating:
+                raise ValidationError(
+                    _('%(wq_rating)s is not the correct total'),
+                    params={'wq_rating': self.wq_rating},
+                )
 
     class Meta:
         verbose_name = 'Macroinvertebrate'

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -287,6 +287,21 @@ class Macroinvertebrates(models.Model):
                     params={'sensitive_total': self.sensitive_total},
                 )
 
+        if((self.clam_or_mussel + self.crane_fly + self.crayfish
+           + self.damselfly + self.dragonfly + self.scud + self.fishfly
+           + self.alderfly + self.mite) * 2) != self.somewhat_sensitive_total:
+                raise ValidationError(
+                    _('%(sensitive_total)s is not the correct total'),
+                    params={'sensitive_total': self.somewhat_sensitive_total},
+                )
+
+        if(self.aquatic_worm + self.blackfly + self.leech + self.midge
+           + self.snail + self.mosquito_larva) != self.tolerant_total:
+                raise ValidationError(
+                    _('%(sensitive_total)s is not the correct total'),
+                    params={'sensitive_total': self.tolerant_total},
+                    )
+
     class Meta:
         verbose_name = 'Macroinvertebrate'
         verbose_name_plural = 'Macroinvertebrates'

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -7,7 +7,7 @@ from django.contrib.gis.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-# from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
 
@@ -277,6 +277,15 @@ class Macroinvertebrates(models.Model):
 
     def __str__(self):
         return self.site.site_name
+
+    def clean(self):
+        if ((self.caddisfly + self.mayfly + self.riffle_beetle
+             + self.stonefly + self.water_penny +
+             self.dobsonfly) * 3) != self.sensitive_total:
+                raise ValidationError(
+                    _('%(sensitive_total)s is not the correct total'),
+                    params={'sensitive_total': self.sensitive_total},
+                )
 
     class Meta:
         verbose_name = 'Macroinvertebrate'

--- a/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
@@ -182,6 +182,7 @@ class MacroTestCase(TestCase):
         # Overall water quality rating
         self.assertEqual(macros.wq_rating, 26)
 
+    """Tests for validating intolerant macroinvertebrates"""
     def test_validate_macroinverts_intolerant(self):
         default_dt = timezone.now()
         site = Site.objects.create_site('test', 'some_type', 'some_slug')
@@ -202,18 +203,53 @@ class MacroTestCase(TestCase):
                                                    damselfly=6, dragonfly=4,
                                                    scud=5, fishfly=7,
                                                    alderfly=8, mite=8,
-                                                   somewhat_sensitive_total=14,
+                                                   somewhat_sensitive_total=98,
                                                    aquatic_worm=12,
                                                    blackfly=9, leech=8,
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
-                                                   tolerant_total=5,
+                                                   tolerant_total=52,
                                                    wq_rating=26)
 
         with self.assertRaises(ValidationError):
             macros.clean()
 
-    def test_validate_macroinverts_no_error(self):
+    def test_validate_macroinverts_intolerant_no_error(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=98,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=52,
+                                                   wq_rating=26)
+        raised = False
+        try:
+            macros.clean()
+        except:
+            raised = True
+        self.assertFalse(raised, 'ValidationError raised')
+
+    """Tests for validating somewhat sensitive macroinvertebrates"""
+    def test_validate_macroinverts_somewhat_sensitive(self):
         default_dt = timezone.now()
         site = Site.objects.create_site('test', 'some_type', 'some_slug')
         macros = Macroinvertebrates.objects.create(site=site,
@@ -238,6 +274,108 @@ class MacroTestCase(TestCase):
                                                    blackfly=9, leech=8,
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
+                                                   tolerant_total=52,
+                                                   wq_rating=26)
+
+        with self.assertRaises(ValidationError):
+            macros.clean()
+
+    def test_validate_macroinverts_somewhat_sensitive_no_error(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=98,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=52,
+                                                   wq_rating=26)
+        raised = False
+        try:
+            macros.clean()
+        except:
+            raised = True
+        self.assertFalse(raised, 'ValidationError raised')
+
+    """Tests for validating tolerant macroinvertebrates"""
+    def test_validate_macroinverts_tolerant(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=98,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
                                                    tolerant_total=5,
                                                    wq_rating=26)
-        self.assertEqual(macros.clean(), None)
+
+        with self.assertRaises(ValidationError):
+            macros.clean()
+
+    def test_validate_macroinverts_tolerant_no_error(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=98,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=52,
+                                                   wq_rating=26)
+        raised = False
+        try:
+            macros.clean()
+        except:
+            raised = True
+        self.assertFalse(raised, 'ValidationError raised')

--- a/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from streamwebs.models import Site
 from streamwebs.models import Macroinvertebrates
+from django.core.exceptions import ValidationError
 
 
 class MacroTestCase(TestCase):
@@ -126,7 +127,7 @@ class MacroTestCase(TestCase):
                                                    mayfly=2, riffle_beetle=1,
                                                    stonefly=1, water_penny=3,
                                                    dobsonfly=0,
-                                                   sensitive_total=7,
+                                                   sensitive_total=21,
                                                    clam_or_mussel=4,
                                                    crane_fly=5, crayfish=2,
                                                    damselfly=6, dragonfly=4,
@@ -155,7 +156,7 @@ class MacroTestCase(TestCase):
         self.assertEqual(macros.stonefly, 1)
         self.assertEqual(macros.water_penny, 3)
         self.assertEqual(macros.dobsonfly, 0)
-        self.assertEqual(macros.sensitive_total, 7)
+        self.assertEqual(macros.sensitive_total, 21)
 
         # Somewhat tolerant
         self.assertEqual(macros.clam_or_mussel, 4)
@@ -180,3 +181,63 @@ class MacroTestCase(TestCase):
 
         # Overall water quality rating
         self.assertEqual(macros.wq_rating, 26)
+
+    def test_validate_macroinverts_intolerant(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=7,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=14,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=5,
+                                                   wq_rating=26)
+
+        with self.assertRaises(ValidationError):
+            macros.clean()
+
+    def test_validate_macroinverts_no_error(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=14,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=5,
+                                                   wq_rating=26)
+        self.assertEqual(macros.clean(), None)

--- a/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
@@ -209,7 +209,7 @@ class MacroTestCase(TestCase):
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
                                                    tolerant_total=52,
-                                                   wq_rating=26)
+                                                   wq_rating=171)
 
         with self.assertRaises(ValidationError):
             macros.clean()
@@ -240,7 +240,7 @@ class MacroTestCase(TestCase):
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
                                                    tolerant_total=52,
-                                                   wq_rating=26)
+                                                   wq_rating=171)
         raised = False
         try:
             macros.clean()
@@ -275,7 +275,7 @@ class MacroTestCase(TestCase):
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
                                                    tolerant_total=52,
-                                                   wq_rating=26)
+                                                   wq_rating=171)
 
         with self.assertRaises(ValidationError):
             macros.clean()
@@ -306,7 +306,7 @@ class MacroTestCase(TestCase):
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
                                                    tolerant_total=52,
-                                                   wq_rating=26)
+                                                   wq_rating=171)
         raised = False
         try:
             macros.clean()
@@ -341,7 +341,7 @@ class MacroTestCase(TestCase):
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
                                                    tolerant_total=5,
-                                                   wq_rating=26)
+                                                   wq_rating=171)
 
         with self.assertRaises(ValidationError):
             macros.clean()
@@ -372,7 +372,73 @@ class MacroTestCase(TestCase):
                                                    midge=7, snail=5,
                                                    mosquito_larva=11,
                                                    tolerant_total=52,
+                                                   wq_rating=171)
+        raised = False
+        try:
+            macros.clean()
+        except:
+            raised = True
+        self.assertFalse(raised, 'ValidationError raised')
+
+    """Tests for validating water quality rating"""
+    def test_validate_wq_rating(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=98,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=52,
                                                    wq_rating=26)
+
+        with self.assertRaises(ValidationError):
+            macros.clean()
+
+    def test_validate_wq_rating_no_error(self):
+        default_dt = timezone.now()
+        site = Site.objects.create_site('test', 'some_type', 'some_slug')
+        macros = Macroinvertebrates.objects.create(site=site,
+                                                   date_time=default_dt,
+                                                   weather='sunny',
+                                                   time_spent=45,
+                                                   num_people=17,
+                                                   riffle=False,
+                                                   pool=True,
+                                                   caddisfly=0,
+                                                   mayfly=2, riffle_beetle=1,
+                                                   stonefly=1, water_penny=3,
+                                                   dobsonfly=0,
+                                                   sensitive_total=21,
+                                                   clam_or_mussel=4,
+                                                   crane_fly=5, crayfish=2,
+                                                   damselfly=6, dragonfly=4,
+                                                   scud=5, fishfly=7,
+                                                   alderfly=8, mite=8,
+                                                   somewhat_sensitive_total=98,
+                                                   aquatic_worm=12,
+                                                   blackfly=9, leech=8,
+                                                   midge=7, snail=5,
+                                                   mosquito_larva=11,
+                                                   tolerant_total=52,
+                                                   wq_rating=171)
         raised = False
         try:
             macros.clean()


### PR DESCRIPTION
fixes issue #78 
documentation on Model.clean() here: https://docs.djangoproject.com/en/1.9/ref/models/instances

## Changes in this PR.
- [X] .clean() method to validate math for macroinverts.
- [X] Tests for .clean() method

## Testing this PR.
1.     docker-compose run web bash
2.     cd streamwebs_frontend
3.     python manage.py test streamwebs/tests/models


### Expected Output.
```
Creating test database for alias 'default'...
................................
----------------------------------------------------------------------
Ran 32 tests in 0.322s

OK
Destroying test database for alias 'default'...

```

@osuosl/devs

