### PR TITLE
add password-reenter check for registration

### DIFF
--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -19,6 +19,15 @@ class UserForm(forms.ModelForm):
             'first_name': _('First Name'),
             'last_name': _('Last Name'),
         }
+    password = forms.CharField(widget=forms.PasswordInput())
+    password_check = forms.CharField(
+        widget=forms.PasswordInput(),
+        label='Repeat your password')
+
+    def clean_password(self):
+        if self.data['password'] != self.data['password_check']:
+            raise forms.ValidationError('Passwords do not match')
+        return self.data['password']
 
 
 class UserProfileForm(forms.ModelForm):

--- a/streamwebs_frontend/streamwebs/tests/forms/test_user_reg_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_user_reg_form.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from streamwebs.forms import UserForm, UserProfileForm
 
 
@@ -11,12 +10,20 @@ class UserFormTestCase(TestCase):
             'email',
             'password',
             'first_name',
-            'last_name'
+            'last_name',
         )
 
     def test_UserForm_fields_exist(self):
         user_form = UserForm()
         self.assertEqual(set(user_form.Meta.fields), set(self.expected_fields))
+        self.assertEqual(
+            user_form.base_fields['password_check'].label,
+            'Repeat your password'
+        )
+        self.assertEqual(
+            str(type(user_form.base_fields['password_check'])),
+            "<class 'django.forms.fields.CharField'>"
+        )
 
 
 class UserProfileFormTestCase(TestCase):
@@ -26,8 +33,5 @@ class UserProfileFormTestCase(TestCase):
 
     def test_UserProfileForm_fields_exist(self):
         user_prof_form = UserProfileForm()
-        for i in range(len(self.expected_fields)):
-            self.assertEqual(
-                user_prof_form.Meta.fields[i],
-                self.expected_fields[i]
-            )
+        self.assertEqual(
+            set(user_prof_form.Meta.fields), set(self.expected_fields))

--- a/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
@@ -1,7 +1,11 @@
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.core.urlresolvers import reverse
 
 
+@override_settings(SCHOOL_CHOICES=(
+    ('a', 'School A'),
+    ('b', 'School B'),
+    ('c', 'School C'),))
 class RegistrateTestCase(TestCase):
     def setUp(self):
         self.client = Client()
@@ -39,22 +43,38 @@ class RegistrateTestCase(TestCase):
         """
         When user submits a good form, the user should see a success message
         """
-        with self.settings(SCHOOL_CHOICES=(
-            ('a', 'School A'),
-            ('b', 'School B'),
-            ('c', 'School C'),
-        )):
-            user_form_response = self.client.post(
-                reverse('streamwebs:register'), {
-                    'username': 'john',
-                    'email': 'john@example.com',
-                    'password': 'johniscool',
-                    'first_name': 'John',
-                    'last_name': 'Johnson',
-                    'school': 'a',
-                    'birthdate': '1995-11-10'
-                }
-            )
+        user_form_response = self.client.post(
+            reverse('streamwebs:register'), {
+                'username': 'john',
+                'email': 'john@example.com',
+                'password': 'johniscool',
+                'first_name': 'John',
+                'last_name': 'Johnson',
+                'password_check': 'johniscool',
+                'school': 'a',
+                'birthdate': '1995-11-10'
+            }
+        )
+        self.assertEqual(user_form_response.status_code, 200)
+        self.assertTrue(user_form_response.context['registered'])
 
-            self.assertEqual(user_form_response.status_code, 200)
-            self.assertTrue(user_form_response.context['registered'])
+    def test_passwords_mismatch(self):
+        bad_pw_response = self.client.post(
+            reverse('streamwebs:register'), {
+                'username': 'john',
+                'email': 'john@example.com',
+                'password': 'johniscool',
+                'first_name': 'John',
+                'last_name': 'Johnson',
+                'password_check': 'johnisnotcool',
+                'school': 'a',
+                'birthdate': '1995-11-10'
+            }
+        )
+        self.assertFormError(
+            bad_pw_response,
+            'user_form',
+            'password',
+            'Passwords do not match'
+        )
+        self.assertFalse(bad_pw_response.context['registered'])

--- a/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_registration_view.py
@@ -1,11 +1,7 @@
-from django.test import Client, TestCase, override_settings
+from django.test import Client, TestCase
 from django.core.urlresolvers import reverse
 
 
-@override_settings(SCHOOL_CHOICES=(
-    ('a', 'School A'),
-    ('b', 'School B'),
-    ('c', 'School C'),))
 class RegistrateTestCase(TestCase):
     def setUp(self):
         self.client = Client()


### PR DESCRIPTION
## Changes in this PR.
- [X] Implements @leian7 's password check and tests from #52 


## Testing this PR.
To run tests:
1. Run docker-compose run web bash to open up an interactive shell
2. Cd to streamwebs_frontend
3. Run python manage.py test streamwebs/tests/forms and python manage.py test streamwebs/tests/views

To see in action:
 1. Run docker-compose up
 2. Go to http://localhost:8000/streamwebs/ and click "register"

### Expected Output.
```
Creating test database for alias 'default'...
..
----------------------------------------------------------------------
Ran 2 tests in 0.005s

OK


Creating test database for alias 'default'...
.Invalid login details: notjohn, badpassword
.Invalid login details: notjohn, johnpassword
.Invalid login details: john, badpassword
.....<ul class="errorlist"><li>password<ul class="errorlist"><li>Passwords do not match</li></ul></li></ul> 
.<ul class="errorlist"><li>username<ul class="errorlist"><li>This field is required.</li></ul></li><li>password_check<ul class="errorlist"><li>This field is required.</li></ul></li><li>password<ul class="errorlist"><li>This field is required.</li></ul></li></ul> <ul class="errorlist"><li>school<ul class="errorlist"><li>This field is required.</li></ul></li><li>birthdate<ul class="errorlist"><li>This field is required.</li></ul></li></ul>
...
----------------------------------------------------------------------
Ran 12 tests in 0.489s

OK
Destroying test database for alias 'default'...
```

@osuosl/devs

