### PR TITLE
use the language names in local formats

### DIFF
--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 # flake8: noqa
 
 """
@@ -174,7 +175,7 @@ PIPELINE = {
 }
 
 LANGUAGES = [
-    ('en-us', _('English')),
-    ('es', _('Spanish')),
-    ('ru', _('Russian')),
+    ('en-us', 'English'),
+    ('es', 'Español'),
+    ('ru', 'Русский'),
 ]


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #97

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] includes a list of languages in the settings.py.dist file in their local formats

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Flake8
2. ./runtests.sh


### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
./runtests.sh
No changes detected
Operations to perform:
  Apply all migrations: admin, contenttypes, streamwebs, auth, sessions
Running migrations:
  No migrations to apply.
Creating test database for alias 'default'...
....................................
----------------------------------------------------------------------
Ran 36 tests in 0.335s

OK
Destroying test database for alias 'default'...
Creating test database for alias 'default'...
..
----------------------------------------------------------------------
Ran 2 tests in 0.005s

OK
Destroying test database for alias 'default'...
Creating test database for alias 'default'...
.Invalid login details: notjohn, badpassword
.Invalid login details: notjohn, johnpassword
.Invalid login details: john, badpassword
.....<ul class="errorlist"><li>username<ul class="errorlist"><li>This field is required.</li></ul></li><li>password<ul class="errorlist"><li>This field is required.</li></ul></li></ul> <ul class="errorlist"><li>school<ul class="errorlist"><li>This field is required.</li></ul></li><li>birthdate<ul class="errorlist"><li>This field is required.</li></ul></li></ul>
...
----------------------------------------------------------------------
Ran 11 tests in 0.405s

OK
Destroying test database for alias 'default'...

```

@osuosl/devs

