### PR TITLE
Added validator for rip_transect slope with tests

### DIFF
--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -364,6 +364,14 @@ class RipTransectManager(models.Manager):
                            slope=slope, notes=notes)
 
 
+def validate_slope(slope):
+    if not(0 <= slope):
+        raise ValidationError(
+            '%(slope)s is not positive.',
+            params={'slope': slope},
+            )
+
+
 class RiparianTransect(models.Model):
     """
     This model corresponds to the Riparian Transect data sheet and has a one-to
@@ -374,7 +382,7 @@ class RiparianTransect(models.Model):
     weather = models.CharField(max_length=255, blank=True)
     site = models.ForeignKey(Site, null=True, on_delete=models.CASCADE)
     slope = models.DecimalField(blank=True, null=True, max_digits=5,
-                                decimal_places=3)
+                                decimal_places=3, validators=[validate_slope])
     notes = models.TextField(blank=True)
 
     zone_1 = models.ForeignKey(TransectZone, on_delete=models.CASCADE,


### PR DESCRIPTION
fixes issue #100 

## Changes in this PR.
- [X] Added validator method for riparian transect's slope field
- [X] Added tests for the validator.

## Testing this PR.
1. docker-compose run web bash
2. cd streamwebs_frontend
3. python manage.py test streamwebs/tests/models

### Expected Output.
```
Creating test database for alias 'default'...
...............................................
----------------------------------------------------------------------
Ran 47 tests in 0.374s

OK
```

@osuosl/devs 