### PR TITLE
Cthalmann/canopy cover validator

### DIFF
--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -471,6 +471,14 @@ class CC_Cardinal(models.Model):
         verbose_name_plural = 'Cardinal Directions'
 
 
+def validate_cover(est_canopy_cover):
+    if not(0 <= est_canopy_cover and est_canopy_cover <= 24):
+        raise ValidationError(
+            '%(est_canopy_cover)s is not 0-24.',
+            params={'est_canopy_cover': est_canopy_cover},
+            )
+
+
 @python_2_unicode_compatible
 class Canopy_Cover(models.Model):
     school = models.CharField(max_length=250)

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -494,7 +494,7 @@ class Canopy_Cover(models.Model):
     west = models.ForeignKey(CC_Cardinal, on_delete=models.CASCADE,
                              related_name='west', null=True)
     est_canopy_cover = models.PositiveIntegerField(default=0,
-                                                   validators=[validate_pH])
+                                                   validators=[validate_cover])
 
     def __str__(self):
         return self.site.site_name

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -493,7 +493,8 @@ class Canopy_Cover(models.Model):
                               related_name='south', null=True)
     west = models.ForeignKey(CC_Cardinal, on_delete=models.CASCADE,
                              related_name='west', null=True)
-    est_canopy_cover = models.PositiveIntegerField(default=0)
+    est_canopy_cover = models.PositiveIntegerField(default=0,
+                                                   validators=[validate_pH])
 
     def __str__(self):
         return self.site.site_name

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -479,6 +479,23 @@ class CC_Cardinal(models.Model):
         verbose_name = 'Cardinal Direction'
         verbose_name_plural = 'Cardinal Directions'
 
+    def clean(self):
+        shaded = 0
+        squares = [self.A, self.B, self.C, self.D, self.E, self.F, self.G,
+            self.H, self.I, self.J, self.K, self.L, self.M, self.N, self.O,
+            self.P, self.Q, self.R, self.S, self.T, self.U, self.V, self.W,
+            self.X]
+
+        for square in squares:
+            if square == True:
+                shaded += 1
+
+        if(shaded != self.num_shaded):
+            raise ValidationError(
+                _('%(num_shaded)s is not the correct total'),
+                params={'num_shaded': self.num_shaded},
+            )
+
 
 def validate_cover(est_canopy_cover):
     if not(0 <= est_canopy_cover and est_canopy_cover <= 96):

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -418,6 +418,14 @@ class CardinalManager(models.Manager):
         return cc_info
 
 
+def validate_shaded(num_shaded):
+    if not(0 <= num_shaded and num_shaded <= 24):
+        raise ValidationError(
+            '%(num_shaded)s is not 0-24.',
+            params={'num_shaded': num_shaded},
+            )
+
+
 @python_2_unicode_compatible
 class CC_Cardinal(models.Model):
     NORTH = 'North'
@@ -459,7 +467,8 @@ class CC_Cardinal(models.Model):
     V = models.BooleanField(default=False, blank=True)
     W = models.BooleanField(default=False, blank=True)
     X = models.BooleanField(default=False, blank=True)
-    num_shaded = models.PositiveIntegerField(default=0)
+    num_shaded = models.PositiveIntegerField(default=0,
+                                             validators=[validate_shaded])
 
     objects = CardinalManager()
 
@@ -472,9 +481,9 @@ class CC_Cardinal(models.Model):
 
 
 def validate_cover(est_canopy_cover):
-    if not(0 <= est_canopy_cover and est_canopy_cover <= 24):
+    if not(0 <= est_canopy_cover and est_canopy_cover <= 96):
         raise ValidationError(
-            '%(est_canopy_cover)s is not 0-24.',
+            '%(est_canopy_cover)s is not 0-96.',
             params={'est_canopy_cover': est_canopy_cover},
             )
 

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -482,12 +482,12 @@ class CC_Cardinal(models.Model):
     def clean(self):
         shaded = 0
         squares = [self.A, self.B, self.C, self.D, self.E, self.F, self.G,
-            self.H, self.I, self.J, self.K, self.L, self.M, self.N, self.O,
-            self.P, self.Q, self.R, self.S, self.T, self.U, self.V, self.W,
-            self.X]
+                   self.H, self.I, self.J, self.K, self.L, self.M, self.N,
+                   self.O, self.P, self.Q, self.R, self.S, self.T, self.U,
+                   self.V, self.W, self.X]
 
         for square in squares:
-            if square == True:
+            if square is True:
                 shaded += 1
 
         if(shaded != self.num_shaded):

--- a/streamwebs_frontend/streamwebs/tests/models/test_canopy_cover.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_canopy_cover.py
@@ -249,7 +249,7 @@ class CanopyCovTestCase(TestCase):
                                               date_time=default_dt, site=site,
                                               weather='cloudy', north=north,
                                               east=east, south=south,
-                                              west=west, est_canopy_cover=23)
+                                              west=west, est_canopy_cover=51)
 
         self.assertEqual(validate_cover(canopyc.est_canopy_cover), None)
 

--- a/streamwebs_frontend/streamwebs/tests/models/test_canopy_cover.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_canopy_cover.py
@@ -211,7 +211,7 @@ class CanopyCovTestCase(TestCase):
         self.assertEqual(canopyc.west.direction, 'West')
 
     def test_validate_cover_good(self):
-        """Tests that est_canopy_cover is in between 0-24."""
+        """Tests that est_canopy_cover is in between 0-96."""
         default_dt = timezone.now()
 
         site = Site.objects.create_site('test', 'some_type', 'some_slug')
@@ -229,7 +229,7 @@ class CanopyCovTestCase(TestCase):
                                                 False, True, True, True, False,
                                                 True, False, False, False,
                                                 False, False, True, True,
-                                                False, False, False, False, 8)
+                                                False, False, False, False, 9)
 
         south = CC_Cardinal.objects.create_shade('South', True, True, True,
                                                  False, False, True, False,
@@ -294,7 +294,7 @@ class CanopyCovTestCase(TestCase):
                                               date_time=default_dt, site=site,
                                               weather='cloudy', north=north,
                                               east=east, south=south,
-                                              west=west, est_canopy_cover=50)
+                                              west=west, est_canopy_cover=100)
 
         with self.assertRaises(ValidationError):
             validate_cover(canopyc.est_canopy_cover)

--- a/streamwebs_frontend/streamwebs/tests/models/test_cc_cardinal.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_cc_cardinal.py
@@ -89,3 +89,31 @@ class CCCardinalTestCase(TestCase):
 
         with self.assertRaises(ValidationError):
             validate_shaded(north.num_shaded)
+
+    def test_clean_with_error(self):
+        north = CC_Cardinal.objects.create_shade('North', True, True, False,
+                                                 False, False, True, False,
+                                                 False, True, True, True,
+                                                 False, True, False, False,
+                                                 False, True, False, True,
+                                                 True, False, True, False,
+                                                 False, 21)
+
+        with self.assertRaises(ValidationError):
+            north.clean()
+
+    def test_clean_no_error(self):
+        north = CC_Cardinal.objects.create_shade('North', True, True, False,
+                                                 False, False, True, False,
+                                                 False, True, True, True,
+                                                 False, True, False, False,
+                                                 False, True, False, True,
+                                                 True, False, True, False,
+                                                 False, 11)
+
+        raised = False
+        try:
+            north.clean()
+        except:
+            raised = True
+        self.assertFalse(raised, 'ValidationError raised')

--- a/streamwebs_frontend/streamwebs/tests/models/test_cc_cardinal.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_cc_cardinal.py
@@ -91,6 +91,8 @@ class CCCardinalTestCase(TestCase):
             validate_shaded(north.num_shaded)
 
     def test_clean_with_error(self):
+        """Check that validation error is risen with clean() method when
+           the number shaded does not match the number of Trues."""
         north = CC_Cardinal.objects.create_shade('North', True, True, False,
                                                  False, False, True, False,
                                                  False, True, True, True,
@@ -103,6 +105,8 @@ class CCCardinalTestCase(TestCase):
             north.clean()
 
     def test_clean_no_error(self):
+        """Checks that no validation error is risen with clean() method when
+           the number shaded matches the number of Trues."""
         north = CC_Cardinal.objects.create_shade('North', True, True, False,
                                                  False, False, True, False,
                                                  False, True, True, True,

--- a/streamwebs_frontend/streamwebs/tests/models/test_cc_cardinal.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_cc_cardinal.py
@@ -2,9 +2,10 @@ from django.test import TestCase
 
 from django.contrib.gis.db import models
 from django.apps import apps
+from django.core.exceptions import ValidationError
 from itertools import chain
 
-from streamwebs.models import CC_Cardinal
+from streamwebs.models import CC_Cardinal, validate_shaded
 
 
 class CCCardinalTestCase(TestCase):
@@ -62,3 +63,29 @@ class CCCardinalTestCase(TestCase):
             if not (field.many_to_one and field.related_model is None)
         )))
         self.assertEqual(sorted(fields), sorted(self.expected_fields.keys()))
+
+    def test_validate_shaded_good(self):
+        """Check that num_shaded is in between 0-24"""
+        north = CC_Cardinal.objects.create_shade('North', True, True, False,
+                                                 False, False, True, False,
+                                                 False, True, True, True,
+                                                 False, True, False, False,
+                                                 False, True, False, True,
+                                                 True, False, True, False,
+                                                 False, 11)
+
+        self.assertEqual(validate_shaded(north.num_shaded), None)
+
+    def test_validate_shaded_too_large(self):
+        """Check that validation error is risen when num_shaded
+           is too large"""
+        north = CC_Cardinal.objects.create_shade('North', True, True, False,
+                                                 False, False, True, False,
+                                                 False, True, True, True,
+                                                 False, True, False, False,
+                                                 False, True, False, True,
+                                                 True, False, True, False,
+                                                 False, 45)
+
+        with self.assertRaises(ValidationError):
+            validate_shaded(north.num_shaded)


### PR DESCRIPTION
fixes issue #79 

## Changes in this PR.
- [X] Adds validator for est_canopy_cover
- [X] Adds test for validator

## Testing this PR.
1.   docker-compose run web bash
2.    cd streamwebs_frontend
3.    python manage.py test streamwebs/tests/models

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
Creating test database for alias 'default'...
..........................................................
----------------------------------------------------------------------
Ran 58 tests in 0.710s

OK
Destroying test database for alias 'default'...


```

@osuosl/devs
