### PR TITLE
Change field name to be consistent w/ model

### DIFF
--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -43,13 +43,13 @@ class UserProfileForm(forms.ModelForm):
 class WQForm(forms.ModelForm):
     class Meta:
         model = Water_Quality
-        fields = ('site', 'date', 'DEQ_wq_level', 'latitude',
+        fields = ('site', 'date', 'DEQ_dq_level', 'latitude',
                   'longitude', 'fish_present', 'live_fish',
                   'dead_fish', 'water_temp_unit',
                   'air_temp_unit', 'notes')
         labels = {'site': _('Stream/Site name:'),
                   'date': _('Date:'),
-                  'DEQ_wq_level': _('DEQ Data Quality Level:'),
+                  'DEQ_dq_level': _('DEQ Data Quality Level:'),
                   'latitude': _('Latitude:'),
                   'longitude': _('Longitude:'),
                   'fish_present': _('Any fish present?'),

--- a/streamwebs_frontend/streamwebs/tests/forms/test_wq_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_wq_form.py
@@ -8,7 +8,7 @@ class WQFormTestCase(TestCase):
         self.expected_fields = (
             'site',
             'date',
-            'DEQ_wq_level',
+            'DEQ_dq_level',
             'latitude',
             'longitude',
             'fish_present',


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Travis broke b/c of a naming inconsistency. This fixes the differences in forms/form tests so that migrations can be run.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Fix inconsistencies in field names

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Open the interactive shell
2. ``./runtests.sh``

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
[root@aa5a0a54ca31 streamwebs]# ./runtests.sh 
No changes detected
Operations to perform:
  Apply all migrations: admin, contenttypes, streamwebs, auth, sessions
Running migrations:
  No migrations to apply.
Creating test database for alias 'default'...
................./usr/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1453: RuntimeWarning: DateTimeField RiparianTransect.date_time received a naive datetime (2016-07-11 14:09:00) while time zone support is active.
  RuntimeWarning)

.............................................Invalid login details: notjohn, badpassword
.Invalid login details: notjohn, johnpassword
.Invalid login details: john, badpassword
.....<ul class="errorlist"><li>password<ul class="errorlist"><li>Passwords do not match</li></ul></li></ul> 
.<ul class="errorlist"><li>username<ul class="errorlist"><li>This field is required.</li></ul></li><li>password_check<ul class="errorlist"><li>This field is required.</li></ul></li><li>password<ul class="errorlist"><li>This field is required.</li></ul></li></ul> <ul class="errorlist"><li>school<ul class="errorlist"><li>This field is required.</li></ul></li><li>birthdate<ul class="errorlist"><li>This field is required.</li></ul></li></ul>
...
----------------------------------------------------------------------
Ran 73 tests in 1.644s

OK
Destroying test database for alias 'default'...

```
