### PR TITLE
Convert views from using site_id to site_slug

### DIFF
--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -17,9 +17,8 @@ class SiteManager(models.Manager):
     """
     Manager for the site class - creates a site to be used in tests
     """
-    def create_site(self, site_name, site_type, site_slug):
-        site = self.create(site_name=site_name, site_type=site_type,
-                           site_slug=site_slug)
+    def create_site(self, site_name, site_type):
+        site = self.create(site_name=site_name, site_type=site_type)
         return site
 
 
@@ -52,7 +51,7 @@ class Site(models.Model):
         if not self.site_slug:
             self.site_slug = origSlug = slugify(self.site_name)[:50]
             # If the generated slug is not unique, append a number
-            for i in xrange(1,99):
+            for i in xrange(1, 99):
                 if not Site.objects.filter(site_slug=self.site_slug).exists():
                     break
                 # Ensure the slug is never longer than it's field's maxiumum

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -9,6 +9,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
+from django.utils.text import slugify
 from django.conf import settings
 
 
@@ -29,10 +30,10 @@ class Site(models.Model):
     location as a pair of latitudinal/longitudinal coordinates and an optional
     text description of entry.
     """
-    site_name = models.CharField(max_length=250, blank=True)
+    site_name = models.CharField(max_length=250, blank=False)
     site_type = models.CharField(max_length=250, blank=True)
     description = models.TextField(blank=True)
-    site_slug = models.SlugField(blank=True)
+    site_slug = models.SlugField(unique=True, blank=True, editable=False)
 
     # Geo Django fields to store a point
     location = models.PointField(null=True, blank=True)
@@ -45,6 +46,18 @@ class Site(models.Model):
 
     def __str__(self):
         return self.site_name
+
+    def save(self, **kwargs):
+        'Ensure site_slug is a unique, not-null field'
+        if not self.site_slug:
+            self.site_slug = origSlug = slugify(self.site_name)[:50]
+            # If the generated slug is not unique, append a number
+            for i in xrange(1,99):
+                if not Site.objects.filter(site_slug=self.site_slug).exists():
+                    break
+                # Ensure the slug is never longer than it's field's maxiumum
+                self.site_slug = "%s%d" % (origSlug[:50-len(str(i))], i)
+        super(Site, self).save()
 
 
 def validate_UserProfile_school(school):

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -32,7 +32,9 @@ class Site(models.Model):
     site_name = models.CharField(max_length=250, blank=False)
     site_type = models.CharField(max_length=250, blank=True)
     description = models.TextField(blank=True)
-    site_slug = models.SlugField(unique=True, blank=True, editable=False)
+    site_slug = models.SlugField(
+        unique=True, blank=False, max_length=50, editable=False
+    )
 
     # Geo Django fields to store a point
     location = models.PointField(null=True, blank=True)

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_view.html
@@ -4,9 +4,7 @@
 {% load filters %}
 {% block title %}{% trans "View Riparian Transect Data" %}{% endblock %}
 {% block body_title %}{% trans "Riparian Transect: " %}{{ transect.date_time }}{% endblock %}
-
 {% block content %}
-
     <div>
         <table>
             <tr>
@@ -15,7 +13,7 @@
             </tr>
             <tr>
                 <th align='left'>{% trans "Site" %}</th>
-                <td>{{ transect.site.site_name }}</td>
+                <td>{{ site.site_name }}</td>
             </tr>
             <tr>
                 <th align='left'>{% trans "Slope of stream bank" %}</th>

--- a/streamwebs_frontend/streamwebs/tests/models/test_canopy_cover.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_canopy_cover.py
@@ -55,7 +55,7 @@ class CanopyCovTestCase(TestCase):
         """Tests that a datasheet correctly corresponds to is specified site"""
         default_dt = timezone.now()
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         north = CC_Cardinal.objects.create_shade('North', True, True, False,
                                                  False, False, True, False,
@@ -94,14 +94,14 @@ class CanopyCovTestCase(TestCase):
 
         self.assertEqual(canopyc.site.site_name, 'test')
         self.assertEqual(canopyc.site.site_type, 'some_type')
-        self.assertEqual(canopyc.site.site_slug, 'some_slug')
+        self.assertEqual(canopyc.site.site_slug, 'test')
 
     def test_datasheet_CreateCanopyCover(self):
         """Tests that a Canopy Cover object is actually created, checks that
            the correct (shaded) value is received from the CC_Cardinal model"""
         default_dt = timezone.now()
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         north = CC_Cardinal.objects.create_shade('North', True, True, False,
                                                  False, False, True, False,
@@ -168,7 +168,7 @@ class CanopyCovTestCase(TestCase):
                       True, True, True, True, True, False, False, True, True,
                       False, True, True, True, True, True, False]
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         north = CC_Cardinal.objects.create_shade('North',
                                                  *(north_bools + [11]))
@@ -214,7 +214,7 @@ class CanopyCovTestCase(TestCase):
         """Tests that est_canopy_cover is in between 0-96."""
         default_dt = timezone.now()
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         north = CC_Cardinal.objects.create_shade('North', True, True, False,
                                                  False, False, True, False,
@@ -259,7 +259,7 @@ class CanopyCovTestCase(TestCase):
 
         default_dt = timezone.now()
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         north = CC_Cardinal.objects.create_shade('North', True, True, False,
                                                  False, False, True, False,

--- a/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
@@ -79,7 +79,7 @@ class MacroTestCase(TestCase):
         """Tests that a datasheet correctly corresponds to a specified site"""
         default_dt = timezone.now()  # default date_time value
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
@@ -108,13 +108,13 @@ class MacroTestCase(TestCase):
 
         self.assertEqual(macros.site.site_name, 'test')
         self.assertEqual(macros.site.site_type, 'some_type')
-        self.assertEqual(macros.site.site_slug, 'some_slug')
+        self.assertEqual(macros.site.site_slug, 'test')
 
     def test_datasheet_SetMacroInfo(self):
         """Tests that macroinvertebrate data is created"""
         default_dt = timezone.now()
 
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
@@ -185,7 +185,7 @@ class MacroTestCase(TestCase):
     """Tests for validating intolerant macroinvertebrates"""
     def test_validate_macroinverts_intolerant(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -216,7 +216,7 @@ class MacroTestCase(TestCase):
 
     def test_validate_macroinverts_intolerant_no_error(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -251,7 +251,7 @@ class MacroTestCase(TestCase):
     """Tests for validating somewhat sensitive macroinvertebrates"""
     def test_validate_macroinverts_somewhat_sensitive(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -282,7 +282,7 @@ class MacroTestCase(TestCase):
 
     def test_validate_macroinverts_somewhat_sensitive_no_error(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -317,7 +317,7 @@ class MacroTestCase(TestCase):
     """Tests for validating tolerant macroinvertebrates"""
     def test_validate_macroinverts_tolerant(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -348,7 +348,7 @@ class MacroTestCase(TestCase):
 
     def test_validate_macroinverts_tolerant_no_error(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -383,7 +383,7 @@ class MacroTestCase(TestCase):
     """Tests for validating water quality rating"""
     def test_validate_wq_rating(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',
@@ -414,7 +414,7 @@ class MacroTestCase(TestCase):
 
     def test_validate_wq_rating_no_error(self):
         default_dt = timezone.now()
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
         macros = Macroinvertebrates.objects.create(site=site,
                                                    date_time=default_dt,
                                                    weather='sunny',

--- a/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_rip_transect.py
@@ -27,9 +27,7 @@ class RiparianTransectTestCase(TestCase):
             'notes': models.TextField,
         }
 
-        self.site = Site.test_objects.create_site('test site',
-                                                  'test site type',
-                                                  'test_site_slug')
+        self.site = Site.test_objects.create_site('test site', 'test type')
 
     def test_fields_exist(self):
         for field, field_type in self.expected_fields.items():
@@ -50,8 +48,7 @@ class RiparianTransectTestCase(TestCase):
                              True)
 
     def test_validate_slope_good(self):
-        site = Site.test_objects.create_site('test site', 'test site type',
-                                             'test_site_slug')
+        site = Site.test_objects.create_site('test site', 'test site type')
         transect = RiparianTransect.objects.create_transect(
             'School of Cool', '2016-07-11 14:09', site, 'Cloudy, no meatballs',
             1.11, 'Notes on transect')
@@ -59,8 +56,7 @@ class RiparianTransectTestCase(TestCase):
         self.assertEqual(validate_slope(transect.slope), None)
 
     def test_validate_slope_bad(self):
-        site = Site.test_objects.create_site('test site', 'test site type',
-                                             'test_site_slug')
+        site = Site.test_objects.create_site('test site', 'test site type')
         transect = RiparianTransect.objects.create_transect(
             'School of Cool', '2016-07-11 14:09', site, 'Cloudy, no meatballs',
             -1.11, 'Notes on transect')
@@ -76,8 +72,8 @@ class RiparianTransectTestCase(TestCase):
             'School of Cool', '2016-07-11 14:09', self.site)
 
         self.assertEqual(transect.site.site_name, 'test site')
-        self.assertEqual(transect.site.site_type, 'test site type')
-        self.assertEqual(transect.site.site_slug, 'test_site_slug')
+        self.assertEqual(transect.site.site_type, 'test type')
+        self.assertEqual(transect.site.site_slug, 'test-site')
 
     def test_transect_creation_req_fields(self):
         transect = RiparianTransect.objects.create_transect(

--- a/streamwebs_frontend/streamwebs/tests/models/test_site_model.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_site_model.py
@@ -51,3 +51,6 @@ class SiteTestCase(TestCase):
         for field in self.optional_fields:
             self.assertEqual(
                 Site._meta.get_field(field).blank, True)
+
+    def test_site_slug_is_unique(self):
+        self.site = Site.test_objects.create_site('test site', 'site type')

--- a/streamwebs_frontend/streamwebs/tests/models/test_site_model.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_site_model.py
@@ -13,7 +13,7 @@ class SiteTestCase(TestCase):
             'site_name': models.CharField,
             'site_type': models.CharField,
             'description': models.TextField,
-            'site_slug': models.SlugField,  # Note: max_length defaults to 50
+            'site_slug': models.SlugField,
             'location': models.PointField,
             'created': models.DateTimeField,
             'modified': models.DateTimeField,
@@ -49,8 +49,33 @@ class SiteTestCase(TestCase):
     def test_optional_fields(self):
         apps.get_model('streamwebs', 'site')
         for field in self.optional_fields:
-            self.assertEqual(
-                Site._meta.get_field(field).blank, True)
+            self.assertEqual(Site._meta.get_field(field).blank, True)
 
     def test_site_slug_is_unique(self):
-        self.site = Site.test_objects.create_site('test site', 'site type')
+        self.siteA = Site.test_objects.create_site('test site', 'site type')
+        self.siteB = Site.test_objects.create_site('test site', 'site type')
+        self.assertNotEqual(self.siteA.site_slug, self.siteB.site_slug)
+        # Long site names are truncated, make sure they are still unique
+        self.siteA = Site.test_objects.create_site(
+            'test site with a really, really, really, REALLY long name', ''
+        )
+        self.siteB = Site.test_objects.create_site(
+            'test site with a really, really, really, REALLY long name', ''
+        )
+        self.assertNotEqual(self.siteA.site_slug, self.siteB.site_slug)
+
+    def test_site_slug_max_length(self):
+        self.siteA = Site.test_objects.create_site(
+            'test site with a really, really, really, REALLY long name', ''
+        )
+        self.assertIs(len(self.siteA.site_slug), 50)
+        # Conflicting long site names must still be max of 50 chars
+        self.siteB = Site.test_objects.create_site(
+            'test site with a really, really, really, REALLY long name', ''
+        )
+        self.assertIs(len(self.siteB.site_slug), 50)
+
+    def test_site_slug_not_empty(self):
+        print "Testing!"
+        self.site = Site.test_objects.create_site('', '')
+        self.assertIsNotNone(self.site.site_slug)

--- a/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_transect_zone.py
@@ -23,8 +23,7 @@ class TransectZoneTestCase(TestCase):
             'comments': models.TextField,
         }
 
-        site = Site.test_objects.create_site('test site', 'test site type',
-                                             'test_site_slug')
+        site = Site.test_objects.create_site('test site', 'test site type')
         self.transect = RiparianTransect.objects.create_transect(
             'School of Cool', '2016-07-27 10:14', site)
 

--- a/streamwebs_frontend/streamwebs/tests/models/test_water_quality.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_water_quality.py
@@ -33,9 +33,7 @@ class WaterQualityTestCase(TestCase):
            'notes'
         }
 
-        self.site = Site.test_objects.create_site('test site',
-                                                  'test site type',
-                                                  'test_site_slug')
+        self.site = Site.test_objects.create_site('test site', 'test type')
 
     def test_fields_exist(self):
         """Tests that all fields are successfully created"""
@@ -63,7 +61,7 @@ class WaterQualityTestCase(TestCase):
 
     def test_datasheet_ManyToOneSite(self):
         """Tests that a datasheet correctly corresponds to a specified site"""
-        site = Site.test_objects.create_site('test', 'some_type', 'some_slug')
+        site = Site.test_objects.create_site('test', 'some_type')
 
         waterq = Water_Quality.objects.create(site=site,
                                               DEQ_dq_level='A',
@@ -79,7 +77,7 @@ class WaterQualityTestCase(TestCase):
         # Assert that site data matches the newly created test site
         self.assertEqual(waterq.site.site_name, 'test')
         self.assertEqual(waterq.site.site_type, 'some_type')
-        self.assertEqual(waterq.site.site_slug, 'some_slug')
+        self.assertEqual(waterq.site.site_slug, site.site_slug)
 
     def test_wq_creation_req_fields(self):
         wq = Water_Quality.objects.create_water_quality(self.site,

--- a/streamwebs_frontend/streamwebs/tests/models/test_wq_sample.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_wq_sample.py
@@ -50,8 +50,7 @@ class WQSampleTestCase(TestCase):
             'fecal_coliform',
         }
 
-        site = Site.test_objects.create_site('test site', 'test site type',
-                                             'test_site_slug')
+        site = Site.test_objects.create_site('test site', 'test site type')
 
         self.water_quality = Water_Quality.objects.create_water_quality(
                              site, '2016-08-03', 'a', 'A', 90, 123,

--- a/streamwebs_frontend/streamwebs/tests/views/test_macro_edit.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_macro_edit.py
@@ -11,8 +11,7 @@ class MacroFormTestCase(TestCase):
         self.user = User.objects.create_user('john', 'john@example.com',
                                              'johnpassword')
         self.client.login(username='john', password='johnpassword')
-        self.site = Site.objects.create_site('Site Name!', 'Site Type!',
-                                             'site_slug')
+        self.site = Site.objects.create_site('Site Name!', 'Site Type!')
         self.expected_fields = ('school', 'date_time', 'weather', 'site',
                                 'time_spent', 'num_people', 'riffle', 'pool',
                                 'caddisfly', 'mayfly', 'riffle_beetle',
@@ -30,12 +29,11 @@ class MacroFormTestCase(TestCase):
         When the user tries to submit a bad (blank) form, the form errors
         should be displayed
         """
-        test_site = Site.test_objects.create_site('test site',
-                                                  'test site type',
-                                                  'test_site_slug')
+        test_site = Site.test_objects.create_site('test site', 'test type')
         response = self.client.post(
             reverse('streamwebs:macroinvertebrate_edit', kwargs={
-                'site_slug': test_site.id}), {}
+                'site_slug': test_site.site_slug
+                }), {}
         )
         self.assertFormError(response, 'macro_form', 'school',
                              'This field is required.')
@@ -47,12 +45,10 @@ class MacroFormTestCase(TestCase):
         appropriately, the user should see a success message
         """
         # TODO MAKE sample site
-        test_site = Site.test_objects.create_site('test site',
-                                                  'test site type',
-                                                  'test_site_slug')
+        test_site = Site.test_objects.create_site('test site', 'test type')
         response = self.client.post(
             reverse('streamwebs:macroinvertebrate_edit', kwargs={
-                'site_slug': test_site.id}), {
+                'site_slug': 'test-site'}), {
                 'school': "aaaa",
                 'date_time': '2016-07-11 14:09',
                 'weather': "aaaa",
@@ -99,12 +95,13 @@ class MacroFormTestCase(TestCase):
         """
         When the user is not logged in, they cannot view the data entry page
         """
-        test_site = Site.test_objects.create_site('test site',
-                                                  'test site type',
-                                                  'test_site_slug')
+        test_site = Site.test_objects.create_site('test site', 'test type')
+
         self.client.logout()
         response = self.client.post(
             reverse('streamwebs:macroinvertebrate_edit', kwargs={
-                'site_slug': test_site.id}))
+                'site_slug': test_site.site_slug
+            })
+        )
         self.assertContains(response, 'You must be logged in to submit data.')
         self.assertEqual(response.status_code, 200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_macro_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_macro_view.py
@@ -5,9 +5,7 @@ from streamwebs.models import Site, Macroinvertebrates
 
 class MacroViewTestCase(TestCase):
     def setUp(self):
-        self.site = Site.test_objects.create_site(
-            'Site Name', 'Site Type', 'site_slug'
-            )
+        self.site = Site.test_objects.create_site('site name', 'site type')
         self.macro = Macroinvertebrates.objects.create_macro(
             self.site, 2, 3, True, True, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5,
             6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8)
@@ -15,7 +13,7 @@ class MacroViewTestCase(TestCase):
             reverse(
                 'streamwebs:macroinvertebrate_view',
                 kwargs={'data_id': self.macro.id,
-                        'site_slug': self.macro.site.id
+                        'site_slug': self.site.site_slug
                         }
             )
         )

--- a/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
@@ -16,11 +16,10 @@ class AddTransectTestCase(TestCase):
         When the user tries to submit a bad (blank) form, the form errors
         should be displayed
         """
-        site = Site.test_objects.create_site('Site Name', 'Site Type',
-                                             'site_slug')
+        site = Site.test_objects.create_site('site name', 'Site Type')
         response = self.client.post(
             reverse('streamwebs:riparian_transect_edit',
-                    kwargs={'site_slug': site.id}
+                    kwargs={'site_slug': site.site_slug}
                     ), {
                 'transect-TOTAL_FORMS': '5',
                 'transect-INITIAL_FORMS': '0',
@@ -36,12 +35,11 @@ class AddTransectTestCase(TestCase):
         When the user submits a form with all required fields filled
         appropriately, the user should see a success message
         """
-        site = Site.test_objects.create_site('Site Name', 'Site Type',
-                                             'site_slug')
+        site = Site.test_objects.create_site('site name', 'Site Type')
         response = self.client.post(
             reverse(
                 'streamwebs:riparian_transect_edit',
-                kwargs={'site_slug': site.id}
+                kwargs={'site_slug': site.site_slug}
             ), {
                     'school': 'School of cool',
                     'date_time': '2016-07-18 14:09:07',
@@ -78,7 +76,6 @@ class AddTransectTestCase(TestCase):
                     'transect-4-hardwoods': 4,
                     'transect-4-shrubs': 3,
                     'transect-4-comments': '5 comments'
-
                 }
         )
         self.assertTemplateUsed(
@@ -93,11 +90,12 @@ class AddTransectTestCase(TestCase):
         When the user is not logged in, they cannot view the data entry page
         """
         self.client.logout()
-        site = Site.test_objects.create_site('Site Name', 'Site Type',
-                                             'site_slug')
+        site = Site.test_objects.create_site('site name', 'Site Type')
         response = self.client.get(
-            reverse('streamwebs:riparian_transect_edit',
-                    kwargs={'site_slug': site.id})
+            reverse(
+                'streamwebs:riparian_transect_edit',
+                kwargs={'site_slug': site.site_slug}
+            )
         )
         self.assertContains(response, 'You must be logged in to submit data.')
         self.assertEqual(response.status_code, 200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_view_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_view_view.py
@@ -6,8 +6,7 @@ from streamwebs.models import Site, TransectZone, RiparianTransect
 class ViewTransectTestCase(TestCase):
 
     def test_data_sheet_view(self):
-        site = Site.test_objects.create_site('Site Name', 'Site Type',
-                                             'site_slug')
+        site = Site.test_objects.create_site('site name', 'Site Type')
         transect = RiparianTransect.objects.create_transect(
             'School Name', '2016-07-22 15:04:00', site
         )
@@ -25,19 +24,17 @@ class ViewTransectTestCase(TestCase):
                 reverse(
                     'streamwebs:riparian_transect_view',
                     kwargs={'data_id': transect.id,
-                            'site_slug': transect.site.id
+                            'site_slug': transect.site.site_slug
                             }
                 )
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
-            response,
-            'streamwebs/datasheets/riparian_transect_view.html'
+            response, 'streamwebs/datasheets/riparian_transect_view.html'
         )
 
     def test_data_sheet_view_content(self):
-        site = Site.test_objects.create_site('Site Name', 'Site Type',
-                                             'site_slug')
+        site = Site.test_objects.create_site('Site Name', 'Site Type')
         transect = RiparianTransect.objects.create_transect(
             'School Name', '2016-07-22 15:04:00', site
         )
@@ -55,11 +52,14 @@ class ViewTransectTestCase(TestCase):
                 reverse(
                     'streamwebs:riparian_transect_view',
                     kwargs={'data_id': transect.id,
-                            'site_slug': transect.site.id
+                            'site_slug': site.site_slug
                             }
                 )
         )
 
+        self.assertTemplateUsed(
+            response, 'streamwebs/datasheets/riparian_transect_view.html'
+        )
         self.assertContains(response, 'Riparian Transect')
         self.assertContains(response, 'School Name')
         self.assertContains(response, 'July 22, 2016, 3:04 p.m.')

--- a/streamwebs_frontend/streamwebs/urls.py
+++ b/streamwebs_frontend/streamwebs/urls.py
@@ -9,23 +9,24 @@ urlpatterns = [
 
     url(r'^sites$', views.sites, name='sites'),
 
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)$', views.site, name='site'),
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)$', views.site, name='site'),
 
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/water/(?P<data_id>\d+)',
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)/water/(?P<data_id>\d+)',
         views.water_quality, name='water_quality'),
 
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/water/edit',
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)/water/edit',
         views.water_quality_edit, name='water_quality_edit'),
 
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/macro/(?P<data_id>\d+)$',
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)/macro/(?P<data_id>\d+)$',
         views.macroinvertebrate, name='macroinvertebrate_view'),
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/macro/edit$',
+
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)/macro/edit$',
         views.macroinvertebrate_edit, name='macroinvertebrate_edit'),
 
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/transect/(?P<data_id>\d+)',
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)/transect/(?P<data_id>\d+)',
         views.riparian_transect_view, name='riparian_transect_view'),
 
-    url(r'^site/(?P<site_slug>[0-9a-zA-Z]+)/transect/edit',
+    url(r'^site/(?P<site_slug>[0-9a-zA-Z-]+)/transect/edit',
         views.riparian_transect_edit, name='riparian_transect_edit'),
 
     url(r'^register/$', views.register, name='register'),

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -245,50 +245,52 @@ def water_quality_edit(request, site_slug):
         'site_type': 'steward',
         'location': {'x': -122.31211423, 'y': 45.11231324}
     }
-    return render(request, 'streamwebs/datasheets/water_quality_edit.html', {
-        'site': site
-    })
+    return render(
+        request,
+        'streamwebs/datasheets/water_quality_edit.html',
+        {'site': site}
+    )
 
 
 def macroinvertebrate(request, site_slug, data_id):
-    data = Macroinvertebrates.objects.filter(site_id=site_slug).get(id=data_id)
-    site = Site.objects.get(id=site_slug)
-    return render(request,
-                  'streamwebs/datasheets/macroinvertebrate_view.html', {
-                      'data': data,
-                      'site': site})
+    site = Site.objects.get(site_slug=site_slug)
+    # data = Macroinvertebrates.objects.filter(site_id=site.id).get(id=data_id)
+    data = Macroinvertebrates.objects.get(id=data_id)
+    return render(
+        request,
+        'streamwebs/datasheets/macroinvertebrate_view.html', {
+            'data': data, 'site': site
+        }
+    )
 
 
 def macroinvertebrate_edit(request, site_slug):
     """
     The view for the submission of a new macroinvertebrate data sheet.
     """
-    site = Site.objects.get(id=site_slug)
+    site = Site.objects.get(site_slug=site_slug)
     added = False
     if request.method == 'POST':
         macro_form = MacroinvertebratesForm(data=request.POST)
-
         if macro_form.is_valid():
             macro_form = macro_form.save()
             added = True
-
-        else:
-            # print macro_form.errors
-            pass
     else:
         macro_form = MacroinvertebratesForm()
 
-    return render(request, 'streamwebs/datasheets/macroinvertebrate_edit.html',
-                  {'macro_form': macro_form,
-                   'added': added,
-                   'site': site})
+    return render(
+        request, 'streamwebs/datasheets/macroinvertebrate_edit.html', {
+            'macro_form': macro_form,
+            'added': added,
+            'site': site
+        }
+    )
 
 
 def riparian_transect_view(request, site_slug, data_id):
-    transects = RiparianTransect.objects.filter(site_id=site_slug)
-    transect = transects.get(id=data_id)
+    site = Site.objects.get(site_slug=site_slug)
+    transect = RiparianTransect.objects.filter(site_id=site.id).get(id=data_id)
     zones = TransectZone.objects.filter(transect_id=transect)
-    site = Site.objects.get(id=site_slug)
 
     # Invoking the database by evaluating the queryset before passing it to the
     # template is necessary in order to pass Travis tests.
@@ -309,7 +311,7 @@ def riparian_transect_edit(request, site_slug):
     The view for the submission of a new riparian transect data sheet.
     """
     added = False
-    site = Site.objects.get(id=site_slug)
+    site = Site.objects.get(site_slug=site_slug)
     transect = RiparianTransect()
     TransectZoneInlineFormSet = inlineformset_factory(
         RiparianTransect, TransectZone,
@@ -317,8 +319,9 @@ def riparian_transect_edit(request, site_slug):
     )
 
     if request.method == 'POST':
-        zone_formset = TransectZoneInlineFormSet(data=request.POST,
-                                                 instance=transect)
+        zone_formset = TransectZoneInlineFormSet(
+            data=request.POST, instance=transect
+        )
         transect_form = RiparianTransectForm(data=request.POST)
 
         if (zone_formset.is_valid() and transect_form.is_valid()):


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #133

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Convert all views from using site_id to site_slug, where appropriate.
- [X] Fix all test issues caused by the change
- [X] Passes flake8

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1 - You'll probably need to migrate your database to apply any changes to models.py:
```
$ docker-compose run web bash
# python streamwebs_frontend/manage.py makemigrations
# python streamwebs_frontend/manage.py migrate
```
2 - Run tests using `# ./runtests`
3 - Check flake8 using `# flake8`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
# flake8
./docs/source/conf.py:284:1: E265 block comment should start with '# '
( lots of these)
./streamwebs_frontend/streamwebs/migrations/0001_initial.py:27:80: E501 line too long (114 > 79 characters)
( lots of these)
```
You should not see any flake8 warnings except for `docs/source/conf.py` and `streamwebs_frontend/streamwebs/migrations/*`.

```
# ./runtests.sh 
No changes detected
Operations to perform:
  Apply all migrations: admin, contenttypes, streamwebs, auth, sessions
Running migrations:
  No migrations to apply.
Creating test database for alias 'default'...
...................................................................................Invalid login details: notjohn, badpassword
.Invalid login details: notjohn, johnpassword
.Invalid login details: john, badpassword
.............<ul class="errorlist"><li>password<ul class="errorlist"><li>Passwords do not match</li></ul></li></ul> 
.<ul class="errorlist"><li>username<ul class="errorlist"><li>This field is required.</li></ul></li><li>password_check<ul class="errorlist"><li>This field is required.</li></ul></li><li>password<ul class="errorlist"><li>This field is required.</li></ul></li><li>email<ul class="errorlist"><li>This field is required.</li></ul></li></ul> <ul class="errorlist"><li>captcha<ul class="errorlist"><li>This field is required.</li></ul></li><li>school<ul class="errorlist"><li>This field is required.</li></ul></li><li>birthdate<ul class="errorlist"><li>This field is required.</li></ul></li></ul>
. <ul class="errorlist"><li>captcha<ul class="errorlist"><li>Incorrect, please try again.</li></ul></li></ul>
. <ul class="errorlist"><li>captcha<ul class="errorlist"><li>Incorrect, please try again.</li></ul></li></ul>
.....
----------------------------------------------------------------------
Ran 106 tests in 1.752s

OK
Destroying test database for alias 'default'...
```

@osuosl/devs
