### PR TITLE
Allow prints in docker

### DIFF
--- a/dockerfiles/Dockerfile.env.dist
+++ b/dockerfiles/Dockerfile.env.dist
@@ -1,3 +1,4 @@
 POSTGRES_DB=streamwebs
 POSTGRES_USER=postgres_user
 POSTGRES_PASSWORD=postgres_pw
+PYTHONUNBUFFERED=0


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #153

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Add `PYTHONUNBUFFERED=0` to `Dockerfile.env.dist`

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Add `print("HELLO!")` to `streamwebs_frontend/streamwebs/__init__.py`
2. Run `docker-compose up`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
subnomo@ultraviolet:~/Documents/streamwebs$ docker-compose up
Starting streamwebs_postgres_host_1
Starting streamwebs_web_1
Attaching to streamwebs_postgres_host_1, streamwebs_web_1
postgres_host_1  | LOG:  database system was shut down at 2016-09-22 22:48:33 UTC
postgres_host_1  | LOG:  MultiXact member wraparound protections are now enabled
postgres_host_1  | LOG:  database system is ready to accept connections
postgres_host_1  | LOG:  autovacuum launcher started
web_1            | HELLO!
web_1            | HELLO!
web_1            | Performing system checks...
web_1            | 
web_1            | System check identified no issues (0 silenced).
web_1            | September 22, 2016 - 15:52:17
web_1            | Django version 1.9.5, using settings 'streamwebs_frontend.settings'
web_1            | Starting development server at http://0.0.0.0:8000/
web_1            | Quit the server with CONTROL-C.
```

@osuosl/devs

