### PR TITLE
Fix pages that use site names or slugs incorrectly.

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -76,8 +76,7 @@ function initialize() {
         markerList[i].index = i;
 
         infoWindows[i] = new google.maps.InfoWindow({
-            content: '<p><a href="' + site.slug + '">' + site.name + '</a></p><p>' + site.description + '</p>',
-        });
+            content: '<p><a href="javascript:submit_map(\'' + site.slug + '\')">' + site.name + '</a></p><p>' + site.description + '</p>',
 
         markerList[i].addListener('click', function () {
             for (let otherWindow of infoWindows) {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/water_quality.html
@@ -1,7 +1,7 @@
 
 {% extends "streamwebs/base.html" %}
 {% load staticfiles %}
-{% block title %}Water Quality - {{site.name}} -{% endblock %}
+{% block title %}Water Quality - {{site.site_name}} -{% endblock %}
 {% load i18n %}
 {% block scripts %}
 {% endblock %}


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

Fixes #168.
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Fix references to `Site.slug` and `Site.name` to instead use `Site.site_slug` and `Site.site_name`
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. See the /sites/ endpoint
2. See a page showing a water quality graph for a site.
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->
1. The /sites/ endpoint should now have a working dropdown, working search bar, and working info windows when you click on a marker in the map
2. The water quality graph should now properly show the site name in the header.

@osuosl/devs
