### PR TITLE
Fix site marker navigation

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -60,7 +60,6 @@ function initialize() {
 
         infoWindows[i] = new google.maps.InfoWindow({
             content: '<p><a href="' + site.slug + '">' + site.name + '</a></><p>' + site.description + '</p>',
-            //content: '<p><a href="javascript:submit_map(\'' + site.slug + '\')">' + site.name + '</a></p><p>' + site.description + '</p>',
         });
 
         markerList[i].addListener('click', function () {

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -59,7 +59,8 @@ function initialize() {
         markerList[i].index = i;
 
         infoWindows[i] = new google.maps.InfoWindow({
-            content: '<p><a href="javascript:submit_map(\'' + site.slug + '\')">' + site.name + '</a></p><p>' + site.description + '</p>',
+            content: '<p><a href="' + site.slug + '">' + site.name + '</a></><p>' + site.description + '</p>',
+            //content: '<p><a href="javascript:submit_map(\'' + site.slug + '\')">' + site.name + '</a></p><p>' + site.description + '</p>',
         });
 
         markerList[i].addListener('click', function () {


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #183 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Fix site marker navigation

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Do docker.
2. ``cd datascripts`` and run ``./get_sites.py``
3. ``docker-compose up`` and visit the sites page in the browser
4. Click on a site marker, navigate to selected site's detail page

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

Should be able to navigate to a selected site's detail page through use of site markers.

@LyonesGamer What is the javascript submit_map() function? You made the change in a previous merge, so I'm curious as to where it came from (since I can't find any info on it).