### PR TITLE
Leian/redirects

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/create_site.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/create_site.html
@@ -11,16 +11,11 @@
 {% block body_title %} Add a New Site {% endblock %}
 
 {% block content %}
-    {% if user.is_authenticated %}
-        <form id='site_form' method='post' enctype="multipart/form-data">
-            {% csrf_token %}
-            {{ site_form.media }}
-            {{ site_form.as_p }}
+    <form id='site_form' method='post' enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ site_form.media }}
+    {{ site_form.as_p }}
 
-            <input type='submit' name='submit' value='{% trans 'Add new site' %}'/>
-        </form>
-    {% else %}
-    <strong>You must be logged in to submit data.</strong>
-
-    {% endif %}
+    <input type='submit' name='submit' value='{% trans 'Add new site' %}'/>
+    </form>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
@@ -1,4 +1,3 @@
-{% extends 'streamwebs/base.html' %}
 {% load staticfiles %}
 {% load i18n %}
 {% load filters %}
@@ -6,25 +5,19 @@
 {% block body_title %}{% trans "Add a new camera point" %}{% endblock %}
 {% block content %}
 
-    {% if user.is_authenticated %}
-        {% if added %}
-        <strong>{% trans "You have successfully added a new camera point." %}</strong>
-
-        {% else %}
-        <form id='pp_monitoring_form' method='post', enctype='multipart/form-data'>
-            {% csrf_token %}
-            {{ camera_form.media }}
-            {{ camera_form.as_p }}
-            {{ pp_formset.as_p }}
-            {{ ppi_formset.as_p }}
-
-            <input type='submit', name='submit', value='Submit' />
-        </form>
-        {% endif %}
+    {% if added %}
+    <strong>{% trans "You have successfully added a new camera point." %}</strong>
 
     {% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-        <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
+    <form id='pp_monitoring_form' method='post', enctype='multipart/form-data'>
+        {% csrf_token %}
+        {{ camera_form.media }}
+        {{ camera_form.as_p }}
+        {{ pp_formset.as_p }}
+        {{ ppi_formset.as_p }}
+
+        <input type='submit', name='submit', value='Submit' />
+    </form>
     {% endif %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
@@ -1,3 +1,4 @@
+{% extends 'streamwebs/base.html' %}
 {% load staticfiles %}
 {% load i18n %}
 {% load filters %}
@@ -5,10 +6,6 @@
 {% block body_title %}{% trans "Add a new camera point" %}{% endblock %}
 {% block content %}
 
-    {% if added %}
-    <strong>{% trans "You have successfully added a new camera point." %}</strong>
-
-    {% else %}
     <form id='pp_monitoring_form' method='post', enctype='multipart/form-data'>
         {% csrf_token %}
         {{ camera_form.media }}
@@ -18,6 +15,5 @@
 
         <input type='submit', name='submit', value='Submit' />
     </form>
-    {% endif %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -6,10 +6,6 @@
 {% block body_title %}{% trans "Add Canopy Cover Survey" %}{% endblock %}
 {% block content %}
 
-    {% if added %}
-        <strong> "You have successfully submitted your Canopy Cover Survey." </strong>
-   
-    {% else %} 
     <form id='canopy_cover_form' method='post'>
         {% csrf_token %}
         <table> <!-- main cc info table -->
@@ -60,5 +56,4 @@
 
     <input type='submit', name='submit', value='Submit' />
     </form>
-    {% endif %}
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -6,7 +6,6 @@
 {% block body_title %}{% trans "Add Canopy Cover Survey" %}{% endblock %}
 {% block content %}
 
-{% if user.is_authenticated %}
     {% if added %}
         <strong> "You have successfully submitted your Canopy Cover Survey." </strong>
    
@@ -62,10 +61,4 @@
     <input type='submit', name='submit', value='Submit' />
     </form>
     {% endif %}
-
-{% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-    <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
-{% endif %}
-
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -16,7 +16,6 @@
 {% endblock %}
 {% block content %}
 <div class="container">  
-    {% if user.is_authenticated %}
         {% if added %}
         <strong>{% trans "You have successfully submitted your Macroinvertebrate data sheet." %}.</strong>
 
@@ -138,10 +137,6 @@
         </form>
         {% endif %}
 
-    {% else %}
-        <p>{% trans "You must be logged in to submit data." %}</p>
-        <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
-    {% endif %}
     </div>  <!-- end container -->
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
@@ -5,17 +5,11 @@
 {% block title %}{% trans "New photo point" %}{% endblock %}
 {% block body_title %}{% trans "Add a new photo point for camera point" %}{% endblock %}
 {% block content %}
-
-    {% if added %}
-    <strong>{% trans "You have successfully added a new photo point" %}</strong>
-
-    {% else %}
     <form id='pp_form' method='post', enctype='multipart/form-data'>
         {% csrf_token %}
         {{ pp_form.as_p }}
         {{ ppi_formset.as_p }}
         <input type='submit', name='submit', value='Submit' />
     </form>
-    {% endif %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
@@ -6,22 +6,16 @@
 {% block body_title %}{% trans "Add a new photo point for camera point" %}{% endblock %}
 {% block content %}
 
-    {% if user.is_authenticated %}
-        {% if added %}
-        <strong>{% trans "You have successfully added a new photo point" %}</strong>
-
-        {% else %}
-        <form id='pp_form' method='post', enctype='multipart/form-data'>
-            {% csrf_token %}
-            {{ pp_form.as_p }}
-            {{ ppi_formset.as_p }}
-            <input type='submit', name='submit', value='Submit' />
-        </form>
-        {% endif %}
+    {% if added %}
+    <strong>{% trans "You have successfully added a new photo point" %}</strong>
 
     {% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-        <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
+    <form id='pp_form' method='post', enctype='multipart/form-data'>
+        {% csrf_token %}
+        {{ pp_form.as_p }}
+        {{ ppi_formset.as_p }}
+        <input type='submit', name='submit', value='Submit' />
+    </form>
     {% endif %}
-{% endblock %}
 
+{% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_view.html
@@ -37,7 +37,7 @@
         </form>
 
     {% else %}
-    <p>You must be logged in to submit data.</p>
+    <a href="{% url 'streamwebs:login' %}?next={{ request.path }}">Log in to add photos for this photo point.</a>
     {% endif %}
 </div>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -6,84 +6,78 @@
 {% block body_title %}{% trans "Riparian Transect" %}{% endblock %}
 {% block content %}
 
-    {% if user.is_authenticated %}
-        {% if added %}
-        <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
-
-        {% else %}
-            <form id='rip_trans_form' method='post'>
-                {% csrf_token %}
-                <table> <!-- main transect info table -->
-                    <tr>{{ transect_form.non_field_errors }}</tr>
-                    <tr>
-                        <th align='left'>{{ transect_form.school.label }}</th>
-                        <td>{{ transect_form.school }}</td>
-                        <td>{{ transect_form.school.errors }}</td>
-                    </tr>
-                    <tr>
-                        <th align='left'>{{ transect_form.date_time.label }}</th>
-                        <td>{{ transect_form.date_time }}</td>
-                        <td>{{ transect_form.date_time.errors }}</td>
-                    </tr>
-                    <tr>
-                        <th align='left'>{{ transect_form.site.label }}</th>
-                        <td>{{ transect_form.site }}</td>
-                        <td>{{ transect_form.site.errors }}</td>
-                    </tr>
-                    <tr>
-                        <th align='left'>{{ transect_form.slope.label }}</th>
-                        <td>{{ transect_form.slope }}</td>
-                        <td>{{ transect_form.slope.errors }}</td>
-                    </tr>
-                    <tr>
-                        <th align='left'>{{ transect_form.weather.label }}</th>
-                        <td>{{ transect_form.weather }}</td>
-                        <td>{{ transect_form.weather.errors }}</td>
-                    </tr>
-
-                    {{ zone_formset.management_form }}
-                    <table> <!-- zones subtable -->
-                        <tr>
-                            <th>{{ 'zone'|get_zone_labels }}</th>
-                            <th>{{ 'conifers'|get_zone_labels }}</th>
-                            <th>{{ 'hardwoods'|get_zone_labels }}</th>
-                            <th>{{ 'shrubs'|get_zone_labels }}</th>
-                            <th>{{ 'comments'|get_zone_labels }}</th>
-                        </tr>
-                    {% for zone_form in zone_formset %}
-                        <tr>
-                            <th></th>
-                            <td>{{ zone_form.conifers.errors }}</td>
-                            <td>{{ zone_form.hardwoods.errors }}</td>
-                            <td>{{ zone_form.shrubs.errors }}</td>
-                            <td>{{ zone_form.comments.errors }}</td>
-                        </tr>
-                        <tr>
-                            <th>
-                                {{ forloop.counter0|plus_one }}<br>
-                                {{ forloop.counter0|get_zone }}
-                            </th>
-                            <td>{{ zone_form.conifers }}</td>
-                            <td>{{ zone_form.hardwoods }}</td>
-                            <td>{{ zone_form.shrubs }}</td>
-                            <td>{{ zone_form.comments }}</td>
-                        </tr>
-                    {% endfor %}
-                    </table> <!-- end zones subtable -->
-
-                    <tr>
-                        <th align='left'>{{ transect_form.notes.label }}</th>
-                        <td>{{ transect_form.notes }}</td>
-                    </tr>
-                </table> <!-- end main transect info table -->
-
-            <input type='submit', name='submit', value='Submit' />
-            </form>
-        {% endif %}
-
+    {% if added %}
+    <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
+    
     {% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-        <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
+        <form id='rip_trans_form' method='post'>
+            {% csrf_token %}
+            <table> <!-- main transect info table -->
+                <tr>{{ transect_form.non_field_errors }}</tr>
+                <tr>
+                    <th align='left'>{{ transect_form.school.label }}</th>
+                    <td>{{ transect_form.school }}</td>
+                    <td>{{ transect_form.school.errors }}</td>
+                </tr>
+                <tr>
+                    <th align='left'>{{ transect_form.date_time.label }}</th>
+                    <td>{{ transect_form.date_time }}</td>
+                    <td>{{ transect_form.date_time.errors }}</td>
+                </tr>
+                <tr>
+                    <th align='left'>{{ transect_form.site.label }}</th>
+                    <td>{{ transect_form.site }}</td>
+                    <td>{{ transect_form.site.errors }}</td>
+                </tr>
+                <tr>
+                    <th align='left'>{{ transect_form.slope.label }}</th>
+                    <td>{{ transect_form.slope }}</td>
+                    <td>{{ transect_form.slope.errors }}</td>
+                </tr>
+                <tr>
+                    <th align='left'>{{ transect_form.weather.label }}</th>
+                    <td>{{ transect_form.weather }}</td>
+                    <td>{{ transect_form.weather.errors }}</td>
+                </tr>
+    
+                {{ zone_formset.management_form }}
+                <table> <!-- zones subtable -->
+                    <tr>
+                        <th>{{ 'zone'|get_zone_labels }}</th>
+                        <th>{{ 'conifers'|get_zone_labels }}</th>
+                        <th>{{ 'hardwoods'|get_zone_labels }}</th>
+                        <th>{{ 'shrubs'|get_zone_labels }}</th>
+                        <th>{{ 'comments'|get_zone_labels }}</th>
+                    </tr>
+                {% for zone_form in zone_formset %}
+                    <tr>
+                        <th></th>
+                        <td>{{ zone_form.conifers.errors }}</td>
+                        <td>{{ zone_form.hardwoods.errors }}</td>
+                        <td>{{ zone_form.shrubs.errors }}</td>
+                        <td>{{ zone_form.comments.errors }}</td>
+                    </tr>
+                    <tr>
+                        <th>
+                            {{ forloop.counter0|plus_one }}<br>
+                            {{ forloop.counter0|get_zone }}
+                        </th>
+                        <td>{{ zone_form.conifers }}</td>
+                        <td>{{ zone_form.hardwoods }}</td>
+                        <td>{{ zone_form.shrubs }}</td>
+                        <td>{{ zone_form.comments }}</td>
+                    </tr>
+                {% endfor %}
+                </table> <!-- end zones subtable -->
+    
+                <tr>
+                    <th align='left'>{{ transect_form.notes.label }}</th>
+                    <td>{{ transect_form.notes }}</td>
+                </tr>
+            </table> <!-- end main transect info table -->
+    
+        <input type='submit', name='submit', value='Submit' />
+        </form>
     {% endif %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -6,79 +6,74 @@
 {% block body_title %}{% trans "Riparian Transect" %}{% endblock %}
 {% block content %}
 
-    {% if added %}
-    <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
-    
-    {% else %}
-        <form id='rip_trans_form' method='post'>
-            {% csrf_token %}
-            <table> <!-- main transect info table -->
-                <tr>{{ transect_form.non_field_errors }}</tr>
+    <form id='rip_trans_form' method='post'>
+        {% csrf_token %}
+        <table> <!-- main transect info table -->
+            <tr>{{ transect_form.non_field_errors }}</tr>
+            <tr>
+                <th align='left'>{{ transect_form.school.label }}</th>
+                <td>{{ transect_form.school }}</td>
+                <td>{{ transect_form.school.errors }}</td>
+            </tr>
+            <tr>
+                <th align='left'>{{ transect_form.date_time.label }}</th>
+                <td>{{ transect_form.date_time }}</td>
+                <td>{{ transect_form.date_time.errors }}</td>
+            </tr>
+            <tr>
+                <th align='left'>{{ transect_form.site.label }}</th>
+                <td>{{ transect_form.site }}</td>
+                <td>{{ transect_form.site.errors }}</td>
+            </tr>
+            <tr>
+                <th align='left'>{{ transect_form.slope.label }}</th>
+                <td>{{ transect_form.slope }}</td>
+                <td>{{ transect_form.slope.errors }}</td>
+            </tr>
+            <tr>
+                <th align='left'>{{ transect_form.weather.label }}</th>
+                <td>{{ transect_form.weather }}</td>
+                <td>{{ transect_form.weather.errors }}</td>
+            </tr>
+
+            {{ zone_formset.management_form }}
+            <table> <!-- zones subtable -->
                 <tr>
-                    <th align='left'>{{ transect_form.school.label }}</th>
-                    <td>{{ transect_form.school }}</td>
-                    <td>{{ transect_form.school.errors }}</td>
+                    <th>{{ 'zone'|get_zone_labels }}</th>
+                    <th>{{ 'conifers'|get_zone_labels }}</th>
+                    <th>{{ 'hardwoods'|get_zone_labels }}</th>
+                    <th>{{ 'shrubs'|get_zone_labels }}</th>
+                    <th>{{ 'comments'|get_zone_labels }}</th>
+                </tr>
+            {% for zone_form in zone_formset %}
+                <tr>
+                    <th></th>
+                    <td>{{ zone_form.conifers.errors }}</td>
+                    <td>{{ zone_form.hardwoods.errors }}</td>
+                    <td>{{ zone_form.shrubs.errors }}</td>
+                    <td>{{ zone_form.comments.errors }}</td>
                 </tr>
                 <tr>
-                    <th align='left'>{{ transect_form.date_time.label }}</th>
-                    <td>{{ transect_form.date_time }}</td>
-                    <td>{{ transect_form.date_time.errors }}</td>
+                    <th>
+                        {{ forloop.counter0|plus_one }}<br>
+                        {{ forloop.counter0|get_zone }}
+                    </th>
+                    <td>{{ zone_form.conifers }}</td>
+                    <td>{{ zone_form.hardwoods }}</td>
+                    <td>{{ zone_form.shrubs }}</td>
+                    <td>{{ zone_form.comments }}</td>
                 </tr>
-                <tr>
-                    <th align='left'>{{ transect_form.site.label }}</th>
-                    <td>{{ transect_form.site }}</td>
-                    <td>{{ transect_form.site.errors }}</td>
-                </tr>
-                <tr>
-                    <th align='left'>{{ transect_form.slope.label }}</th>
-                    <td>{{ transect_form.slope }}</td>
-                    <td>{{ transect_form.slope.errors }}</td>
-                </tr>
-                <tr>
-                    <th align='left'>{{ transect_form.weather.label }}</th>
-                    <td>{{ transect_form.weather }}</td>
-                    <td>{{ transect_form.weather.errors }}</td>
-                </tr>
-    
-                {{ zone_formset.management_form }}
-                <table> <!-- zones subtable -->
-                    <tr>
-                        <th>{{ 'zone'|get_zone_labels }}</th>
-                        <th>{{ 'conifers'|get_zone_labels }}</th>
-                        <th>{{ 'hardwoods'|get_zone_labels }}</th>
-                        <th>{{ 'shrubs'|get_zone_labels }}</th>
-                        <th>{{ 'comments'|get_zone_labels }}</th>
-                    </tr>
-                {% for zone_form in zone_formset %}
-                    <tr>
-                        <th></th>
-                        <td>{{ zone_form.conifers.errors }}</td>
-                        <td>{{ zone_form.hardwoods.errors }}</td>
-                        <td>{{ zone_form.shrubs.errors }}</td>
-                        <td>{{ zone_form.comments.errors }}</td>
-                    </tr>
-                    <tr>
-                        <th>
-                            {{ forloop.counter0|plus_one }}<br>
-                            {{ forloop.counter0|get_zone }}
-                        </th>
-                        <td>{{ zone_form.conifers }}</td>
-                        <td>{{ zone_form.hardwoods }}</td>
-                        <td>{{ zone_form.shrubs }}</td>
-                        <td>{{ zone_form.comments }}</td>
-                    </tr>
-                {% endfor %}
-                </table> <!-- end zones subtable -->
-    
-                <tr>
-                    <th align='left'>{{ transect_form.notes.label }}</th>
-                    <td>{{ transect_form.notes }}</td>
-                </tr>
-            </table> <!-- end main transect info table -->
-    
-        <input type='submit', name='submit', value='Submit' />
-        </form>
-    {% endif %}
+            {% endfor %}
+            </table> <!-- end zones subtable -->
+
+            <tr>
+                <th align='left'>{{ transect_form.notes.label }}</th>
+                <td>{{ transect_form.notes }}</td>
+            </tr>
+        </table> <!-- end main transect info table -->
+
+    <input type='submit', name='submit', value='Submit' />
+    </form>
 
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
@@ -18,115 +18,104 @@
 
 {% block content %}
     <div class="container">
-        {% if user.is_authenticated %}
-            {% if added %}
-                <strong>{% trans "You have successfully submitted your Soil Survey data sheet." %}</strong>
-    
-            {% else %}
-                <h3 align="center">{{ site.site_name }}</h3>
-                <h4 align="center">{% trans "New Riparian Soil Survey" %}</h4>
-                <form id='soil_from' method='post' action'{{ request.path }}'>
-                    {% csrf_token %}
-    
-                <div class="row">
-                    <div class="col s6">
-                        <div class ="input-field">
-                            <p>{{ soil_form.school.label }}</p>
-                            <p>{{ soil_form.school.errors | striptags }}</p>
-                            <p>{{ soil_form.school }}</p>
-                        </div>
-                    </div>
-    
-                    <div class="col s6">
-                        <p>{{ soil_form.date.label }}</p>
-                        <p>{{ soil_form.date.errors | striptags }}</p>
-                        <p>{{ soil_form.date }}</p>
-                    </div>
-    
-                    <div class="col s12">
-                        <p>{{ soil_form.weather.label }}</p>
-                        <p>{{ soil_form.weather.errors | striptags }}</p>
-                        <p>{{ soil_form.weather }}</p>
-                    </div>
+        <h3 align="center">{{ site.site_name }}</h3>
+        <h4 align="center">{% trans "New Riparian Soil Survey" %}</h4>
+        <form id='soil_from' method='post' action'{{ request.path }}'>
+            {% csrf_token %}
+
+        <div class="row">
+            <div class="col s6">
+                <div class ="input-field">
+                    <p>{{ soil_form.school.label }}</p>
+                    <p>{{ soil_form.school.errors | striptags }}</p>
+                    <p>{{ soil_form.school }}</p>
                 </div>
-    
-                <!-- Container so that radio buttons render vertically -->
-                <div class="container">
-                    <div class="row">
-                        <div class="col s3 pull-s1">
-                            <p>Landscape Position</p>
-                            {{ soil_form.landscape_pos.errors| striptags }}
-                            <div class="input-field">
-                                {% for radio in soil_form.landscape_pos %}
-                                    {{ radio.tag }}
-                                    <label for="{{radio.id_for_label }}">
-                                        {{radio.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        <div class="col s3 push-s1">
-                            <p>Cover Type</p>
-                            {{ soil_form.cover_type.errors| striptags }}
-                            <div class="input-field">
-                                {% for radio in soil_form.cover_type %}
-                                    {{ radio.tag }}
-                                    <label for="{{radio.id_for_label }}">
-                                        {{radio.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        <div class="col s3 push-s3">
-                            <p>Land Use</p>
-                            {{ soil_form.land_use.errors| striptags }}
-                            <div class="input-field">
-                                {% for radio in soil_form.land_use %}
-                                    {{ radio.tag }}
-                                    <label for="{{radio.id_for_label }}">
-                                        {{radio.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                </div> <!-- end middle container -->
+            </div>
 
-                <br />
-                <div class="row">
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ soil_form.soil_type.label }}
-                            {{ soil_form.soil_type.errors | striptags }}
-                            {{ soil_form.soil_type }}
-                        </div>
-                    </div>
+            <div class="col s6">
+                <p>{{ soil_form.date.label }}</p>
+                <p>{{ soil_form.date.errors | striptags }}</p>
+                <p>{{ soil_form.date }}</p>
+            </div>
 
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ soil_form.distance.label }}
-                            {{ soil_form.distance.errors | striptags }}
-                            {{ soil_form.distance }}
-                        </div>
-                    </div>
-                </div>
+            <div class="col s12">
+                <p>{{ soil_form.weather.label }}</p>
+                <p>{{ soil_form.weather.errors | striptags }}</p>
+                <p>{{ soil_form.weather }}</p>
+            </div>
+        </div>
 
-                <div class="row">
+        <!-- Container so that radio buttons render vertically -->
+        <div class="container">
+            <div class="row">
+                <div class="col s3 pull-s1">
+                    <p>Landscape Position</p>
+                    {{ soil_form.landscape_pos.errors| striptags }}
                     <div class="input-field">
-                        {{soil_form.site_char.label }}
-                        {{ soil_form.site_char.errors | striptags }}
-                        {{ soil_form.site_char }}
+                        {% for radio in soil_form.landscape_pos %}
+                            {{ radio.tag }}
+                            <label for="{{radio.id_for_label }}">
+                                {{radio.choice_label }}
+                            </label>
+                        {% endfor %}
                     </div>
                 </div>
-    
-                <input class="waves-effect btn", type='submit', name='submit', value='Submit' />
-            </form>
-            {% endif %}
-    
-        {% else %}
-            <p>{% trans "You must be logged in to submit data." %}</p>
-            <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
-        {% endif %}
+                <div class="col s3 push-s1">
+                    <p>Cover Type</p>
+                    {{ soil_form.cover_type.errors| striptags }}
+                    <div class="input-field">
+                        {% for radio in soil_form.cover_type %}
+                            {{ radio.tag }}
+                            <label for="{{radio.id_for_label }}">
+                                {{radio.choice_label }}
+                            </label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col s3 push-s3">
+                    <p>Land Use</p>
+                    {{ soil_form.land_use.errors| striptags }}
+                    <div class="input-field">
+                        {% for radio in soil_form.land_use %}
+                            {{ radio.tag }}
+                            <label for="{{radio.id_for_label }}">
+                                {{radio.choice_label }}
+                            </label>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div> <!-- end middle container -->
+
+        <br />
+        <div class="row">
+            <div class="col s6">
+                <div class="input-field">
+                    {{ soil_form.soil_type.label }}
+                    {{ soil_form.soil_type.errors | striptags }}
+                    {{ soil_form.soil_type }}
+                </div>
+            </div>
+
+            <div class="col s6">
+                <div class="input-field">
+                    {{ soil_form.distance.label }}
+                    {{ soil_form.distance.errors | striptags }}
+                    {{ soil_form.distance }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="input-field">
+                {{soil_form.site_char.label }}
+                {{ soil_form.site_char.errors | striptags }}
+                {{ soil_form.site_char }}
+            </div>
+        </div>
+
+        <input class="waves-effect btn", type='submit', name='submit', value='Submit' />
+    </form>
     </div>  <!-- end container -->
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -11,31 +11,23 @@
 {% endblock %}
 
 {% block content %}
-{% if editable %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-    <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
-{% else %}
-    {% if added %}
-        <strong>Success!</strong>
-
-        <!-- Display errors, if any (should be improved/more CSS friendly) -->
-        <!-- {% for field in wq_form %}
-            {% if field.errors %}
-                <br>{{ field.label }}</br>
-                {% for error in field.errors %}
-                    <br>...{{ error }}</br>
-                {% endfor %}
-            {% endif %}
-        {% endfor %}
-        {% for field in sample_formset %}
-            {% if field.errors %}
-                <br>{{ field.label }}</br>
-                {% for error in field.errors %}
-                    <br>,,,{{ error }}</br>
-                {% endfor %}
-            {% endif %}
-        {% endfor %} -->
-    {% endif %}
+    <!-- Display errors, if any (should be improved/more CSS friendly) -->
+    <!-- {% for field in wq_form %}
+        {% if field.errors %}
+            <br>{{ field.label }}</br>
+            {% for error in field.errors %}
+                <br>...{{ error }}</br>
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    {% for field in sample_formset %}
+        {% if field.errors %}
+            <br>{{ field.label }}</br>
+            {% for error in field.errors %}
+                <br>,,,{{ error }}</br>
+            {% endfor %}
+        {% endif %}
+    {% endfor %} -->
 
     <div class="container">
         <form id="water_quality_form" action="" method="POST">
@@ -364,5 +356,4 @@
             {% endif %}
         </form>
     </div>
-{% endif %}
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -11,11 +11,11 @@
 {% endblock %}
 
 {% block content %}
-{% if not user.is_authenticated and editable %}
+{% if editable %}
     <p>{% trans "You must be logged in to submit data." %}</p>
     <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
 {% else %}
-    {% if user.is_authenticated and added %}
+    {% if added %}
         <strong>Success!</strong>
 
         <!-- Display errors, if any (should be improved/more CSS friendly) -->
@@ -359,7 +359,7 @@
                 {{ wq_form.notes }}
             </div>
 
-            {% if user.is_authenticated and editable %}
+            {% if editable %}
                 <input class="waves-effect btn" type="submit" value="Submit">
             {% endif %}
         </form>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/login.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/login.html
@@ -6,10 +6,18 @@
 {% block body_title %}{% trans "Log In" %}{% endblock %}
 {% block content %}
   <div class="container">
+    {% if messages %}
+        {% for message in messages %}
+        <strong>{{ message }}</strong>
+        {% endfor %}
+    {% else %}
+        No messages???
+    {% endif %}
     <div class="row">
-        <form class="col s4 offset-s4" id='login_form' method='post' action='/streamwebs/login/'>
+        <form class="col s4 offset-s4" id='login_form' method='post' action='./?next={{ redirect_to }}'>
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ request.GET.next }}" />
+            Will return to: {{ request.GET.next }}
             {% trans "Username:" %}<input type='text' name='username' value='' size='50' />
             <br />
             {% trans "Password:" %}<input type='password' name='password' value='' size='50' />

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/login.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/login.html
@@ -10,14 +10,11 @@
         {% for message in messages %}
         <strong>{{ message }}</strong>
         {% endfor %}
-    {% else %}
-        No messages???
     {% endif %}
     <div class="row">
         <form class="col s4 offset-s4" id='login_form' method='post' action='./?next={{ redirect_to }}'>
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ request.GET.next }}" />
-            Will return to: {{ request.GET.next }}
             {% trans "Username:" %}<input type='text' name='username' value='' size='50' />
             <br />
             {% trans "Password:" %}<input type='password' name='password' value='' size='50' />

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/login.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/login.html
@@ -9,6 +9,7 @@
     <div class="row">
         <form class="col s4 offset-s4" id='login_form' method='post' action='/streamwebs/login/'>
             {% csrf_token %}
+            <input type="hidden" name="next" value="{{ request.GET.next }}" />
             {% trans "Username:" %}<input type='text' name='username' value='' size='50' />
             <br />
             {% trans "Password:" %}<input type='password' name='password' value='' size='50' />

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/navigation.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/navigation.html
@@ -35,7 +35,7 @@
         {% if user.is_authenticated %}
             <li><a href="{% url 'streamwebs:logout' %}">Logout</a></li>
         {% else %}
-            <li><a href="{% url 'streamwebs:login' %}">Login</a></li>
+        <li><a href="{% url 'streamwebs:login' %}?next={{ request.path }}">Login</a></li>
             <li><a href="{% url 'streamwebs:register' %}">Create Account</a></li>
         {% endif %}
       </ul>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
@@ -6,16 +6,11 @@
 {% block body_title %}{{ site.site_name }}{% endblock %}
 
 {% block content %}
-        {% if updated %}
-        <strong>{% trans 'You have successfully updated ' %}<a href="{% url 'streamwebs:site' site.site_slug %}">{{ site.site_name }}.</a></strong>
-        
-        {% else %}
-        <form id='site_form' method='post' enctype="multipart/form-data" action={% url 'streamwebs:update_site' site.site_slug %}>
-            {% csrf_token %}
-            {{ site_form.media }}
-            {{ site_form.as_p }}
+    <form id='site_form' method='post' enctype="multipart/form-data" action={% url 'streamwebs:update_site' site.site_slug %}>
+        {% csrf_token %}
+        {{ site_form.media }}
+        {{ site_form.as_p }}
 
-            <input type='submit' name='submit' value='{% trans 'Update site' %}'/>
-        </form>
-        {% endif %}
+        <input type='submit' name='submit' value='{% trans 'Update site' %}'/>
+    </form>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
@@ -6,7 +6,6 @@
 {% block body_title %}{{ site.site_name }}{% endblock %}
 
 {% block content %}
-    {% if user.is_authenticated %}
         {% if updated %}
         <strong>{% trans 'You have successfully updated ' %}<a href="{% url 'streamwebs:site' site.site_slug %}">{{ site.site_name }}.</a></strong>
         
@@ -19,7 +18,4 @@
             <input type='submit' name='submit' value='{% trans 'Update site' %}'/>
         </form>
         {% endif %}
-    {% else %}
-    <strong>You must be logged in to edit a site.</strong>
-    {% endif %}
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/tests/views/test_camerapoint_add.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_camerapoint_add.py
@@ -109,5 +109,11 @@ class AddCameraPointTestCase(TestCase):
         response = self.client.get(
             reverse('streamwebs:camera_point_add',
                     kwargs={'site_slug': site.site_slug}))
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:camera_point_add',
+                        kwargs={'site_slug': site.site_slug})),
+            status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_cc_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_cc_edit_view.py
@@ -1,7 +1,7 @@
 from django.test import Client, TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
-from streamwebs.models import Site, School
+from streamwebs.models import Site, School, Canopy_Cover
 
 
 class AddCanopyCoverTestCase(TestCase):
@@ -30,7 +30,10 @@ class AddCanopyCoverTestCase(TestCase):
         self.assertFormError(
             response, 'canopy_cover_form', 'school', 'This field is required.'
         )
-        self.assertFalse(response.context['added'])
+        self.assertTemplateUsed(
+            response,
+            'streamwebs/datasheets/canopy_cover_edit.html'
+        )
 
     def test_view_with_good_data(self):
         """
@@ -164,12 +167,19 @@ class AddCanopyCoverTestCase(TestCase):
                 'est_canopy_cover': 49
                }
         )
-        self.assertTemplateUsed(
+        self.assertTemplateNotUsed(
             response,
             'streamwebs/datasheets/canopy_cover_edit.html'
         )
-        self.assertTrue(response.context['added'])
-        self.assertEqual(response.status_code, 200)
+
+        self.assertRedirects(
+            response,
+            reverse('streamwebs:canopy_cover',
+                    kwargs={'site_slug': site.site_slug,
+                            'data_id': Canopy_Cover.objects.last().id}
+                    ),
+            status_code=302,
+            target_status_code=200)
 
     def test_view_with_not_logged_in_user(self):
         """
@@ -183,6 +193,11 @@ class AddCanopyCoverTestCase(TestCase):
                 kwargs={'site_slug': site.site_slug}
             )
         )
+        self.assertTemplateNotUsed(
+            response,
+            'streamwebs/datasheets/canopy_cover_edit.html'
+        )
+
         self.assertRedirects(
             response,
             (reverse('streamwebs:login') + '?next=' +

--- a/streamwebs_frontend/streamwebs/tests/views/test_cc_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_cc_edit_view.py
@@ -183,7 +183,10 @@ class AddCanopyCoverTestCase(TestCase):
                 kwargs={'site_slug': site.site_slug}
             )
         )
-        self.assertContains(
-            response, 'You must be logged in to submit data.'
-        )
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:canopy_cover_edit',
+                        kwargs={'site_slug': site.site_slug})),
+            status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_create_site_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_create_site_view.py
@@ -42,5 +42,7 @@ class CreateSiteTestCase(TestCase):
         self.client.logout()
         response = self.client.get(reverse('streamwebs:create_site'))
 
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response, reverse('streamwebs:login') + '?next=' + reverse(
+                'streamwebs:create_site'), status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_login_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_login_view.py
@@ -47,7 +47,7 @@ class LoginTestCase(TestCase):
         )
         self.assertRedirects(
             response_bad_pass,
-            reverse('streamwebs:login'),
+            reverse('streamwebs:login') + '?next=',
             status_code=302,
             target_status_code=200
         )
@@ -62,7 +62,7 @@ class LoginTestCase(TestCase):
         )
         self.assertRedirects(
             response_bad_name,
-            reverse('streamwebs:login'),
+            reverse('streamwebs:login') + '?next=',
             status_code=302,
             target_status_code=200
         )
@@ -77,7 +77,7 @@ class LoginTestCase(TestCase):
         )
         self.assertRedirects(
             response_both_bad,
-            reverse('streamwebs:login'),
+            reverse('streamwebs:login') + '?next=',
             status_code=302,
             target_status_code=200
         )

--- a/streamwebs_frontend/streamwebs/tests/views/test_login_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_login_view.py
@@ -45,7 +45,12 @@ class LoginTestCase(TestCase):
             reverse('streamwebs:login'),
             {'username': 'john', 'password': 'badpassword'}
         )
-        self.assertContains(response_bad_pass, 'Invalid credentials')
+        self.assertRedirects(
+            response_bad_pass,
+            reverse('streamwebs:login'),
+            status_code=302,
+            target_status_code=200
+        )
 
     def test_bad_username_good_password(self):
         """
@@ -55,7 +60,12 @@ class LoginTestCase(TestCase):
             reverse('streamwebs:login'),
             {'username': 'notjohn', 'password': 'johnpassword'}
         )
-        self.assertContains(response_bad_name, 'Invalid credentials')
+        self.assertRedirects(
+            response_bad_name,
+            reverse('streamwebs:login'),
+            status_code=302,
+            target_status_code=200
+        )
 
     def test_bad_username_bad_password(self):
         """
@@ -65,7 +75,12 @@ class LoginTestCase(TestCase):
             reverse('streamwebs:login'),
             {'username': 'notjohn', 'password': 'badpassword'}
         )
-        self.assertContains(response_both_bad, 'Invalid credentials')
+        self.assertRedirects(
+            response_both_bad,
+            reverse('streamwebs:login'),
+            status_code=302,
+            target_status_code=200
+        )
 
     def test_logout_when_logged_in(self):
         """

--- a/streamwebs_frontend/streamwebs/tests/views/test_macro_edit.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_macro_edit.py
@@ -98,5 +98,8 @@ class MacroFormTestCase(TestCase):
                 'site_slug': self.site.site_slug
             })
         )
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(response,
+                             reverse('streamwebs:login') + '?next=' + reverse(
+                                 'streamwebs:macroinvertebrate_edit',
+                                 kwargs={'site_slug': self.site.site_slug}),
+                             status_code=302, target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_photopoint_add.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_photopoint_add.py
@@ -80,5 +80,12 @@ class AddPhotoPointTestCase(TestCase):
             reverse('streamwebs:photo_point_add',
                     kwargs={'site_slug': self.cp.site.site_slug,
                             'cp_id': self.cp.id}))
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:photo_point_add',
+                        kwargs={'site_slug': self.cp.site.site_slug,
+                                'cp_id': self.cp.id})),
+            status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_photopoint_add.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_photopoint_add.py
@@ -1,7 +1,7 @@
 from django.test import Client, TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
-from streamwebs.models import Site, CameraPoint
+from streamwebs.models import Site, CameraPoint, PhotoPoint
 from streamwebs.util.temp_img import get_temporary_image
 
 
@@ -38,7 +38,10 @@ class AddPhotoPointTestCase(TestCase):
                              'This field is required.')
         self.assertFormError(response, 'pp_form', 'camera_height',
                              'This field is required.')
-        self.assertFalse(response.context['added'])
+        self.assertTemplateUsed(
+            response,
+            'streamwebs/datasheets/photo_point_add.html'
+        )
 
     def test_view_with_good_data(self):
         """User submits good data: """
@@ -66,12 +69,18 @@ class AddPhotoPointTestCase(TestCase):
                         'photo_point-0-date': '2016-09-21',
                     }
         )
-        self.assertTemplateUsed(
+        self.assertTemplateNotUsed(
             response,
             'streamwebs/datasheets/photo_point_add.html'
         )
-        self.assertTrue(response.context['added'])
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            reverse('streamwebs:photo_point',
+                    kwargs={'site_slug': self.cp.site.site_slug,
+                            'cp_id': self.cp.id,
+                            'pp_id': PhotoPoint.test_objects.last().id}),
+            status_code=302,
+            target_status_code=200)
 
     def test_view_with_not_logged_in_user(self):
         """If not logged in, user can't view data entry"""

--- a/streamwebs_frontend/streamwebs/tests/views/test_photopoint_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_photopoint_view.py
@@ -67,7 +67,6 @@ class ViewPhotoPointTestCase(TestCase):
             response,
             'streamwebs/datasheets/photo_point_view.html'
         )
-        print(response)
         self.assertContains(response, "<form id='ppi_form'")
         self.assertTrue(response.context['added'])
         self.assertEqual(response.status_code, 200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
@@ -98,5 +98,10 @@ class AddTransectTestCase(TestCase):
                 kwargs={'site_slug': site.site_slug}
             )
         )
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:riparian_transect_edit',
+                        kwargs={'site_slug': site.site_slug})),
+            status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
@@ -1,7 +1,7 @@
 from django.test import Client, TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
-from streamwebs.models import Site, School
+from streamwebs.models import Site, School, RiparianTransect
 
 
 class AddTransectTestCase(TestCase):
@@ -29,7 +29,6 @@ class AddTransectTestCase(TestCase):
         )
         self.assertFormError(response, 'transect_form', 'school',
                              'This field is required.')
-        self.assertFalse(response.context['added'])
 
     def test_view_with_good_data(self):
         """
@@ -79,12 +78,14 @@ class AddTransectTestCase(TestCase):
                     'transect-4-comments': '5 comments'
                 }
         )
-        self.assertTemplateUsed(
+        self.assertRedirects(
             response,
-            'streamwebs/datasheets/riparian_transect_edit.html'
-        )
-        self.assertTrue(response.context['added'])
-        self.assertEqual(response.status_code, 200)
+            reverse('streamwebs:riparian_transect',
+                    kwargs={'site_slug': site.site_slug,
+                            'data_id': RiparianTransect.test_objects.last().id}
+                    ),
+            status_code=302,
+            target_status_code=200)
 
     def test_view_with_not_logged_in_user(self):
         """

--- a/streamwebs_frontend/streamwebs/tests/views/test_soil_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_soil_edit_view.py
@@ -30,7 +30,8 @@ class AddSoilSurveyTestCase(TestCase):
         )
         self.assertFormError(response, 'soil_form', 'school',
                              'This field is required.')
-        self.assertFalse(response.context['added'])
+        self.assertTemplateUsed(response,
+                                'streamwebs/datasheets/soil_edit.html')
 
     def test_edit_view_with_good_data(self):
         """
@@ -56,6 +57,8 @@ class AddSoilSurveyTestCase(TestCase):
         )
         soil = Soil_Survey.objects.order_by('-id')[0]
 
+        self.assertTemplateNotUsed(response,
+                                   'streamwebs/datasheets/soil_edit.html')
         self.assertRedirects(response, reverse(
             'streamwebs:soil',
             kwargs={'site_slug': self.site.site_slug, 'data_id': soil.id}),
@@ -73,5 +76,10 @@ class AddSoilSurveyTestCase(TestCase):
                 kwargs={'site_slug': site.site_slug}
             )
         )
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:soil_edit',
+                        kwargs={'site_slug': site.site_slug})),
+            status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_update_site.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_update_site.py
@@ -6,12 +6,12 @@ from streamwebs.models import Site
 
 class UpdateSiteTestCase(TestCase):
     def setUp(self):
+        self.site = Site.test_objects.create_site('Creaky Creek')
+
         self.client = Client()
         self.user = User.objects.create_user('john', 'john@example.com',
                                              'johnpassword')
         self.client.login(username='john', password='johnpassword')
-
-        self.site = Site.test_objects.create_site('Creaky Creek')
 
     def test_prepopulate_siteform(self):
         """View should first contain form prepopulated w requested site info"""
@@ -25,17 +25,23 @@ class UpdateSiteTestCase(TestCase):
 
     def test_successful_site_update(self):
         """Tests that update is successful if all data valid"""
+        site = Site.test_objects.create_site('Creaky Creek')
+        modified = site.modified
+
         response = self.client.post(reverse(
             'streamwebs:update_site',
-            kwargs={'site_slug': self.site.site_slug}), {
+            kwargs={'site_slug': site.site_slug}), {
                 'site_name': 'Shrieky Creek',
                 'description': 'some description',
                 'location': 'POINT(-121.3846841 44.0612385)'})
 
-        self.assertTrue(response.context['updated'])
-        self.assertNotEqual(self.site.modified,
-                            response.context['modified_time'])
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            reverse('streamwebs:site',
+                    kwargs={'site_slug': Site.test_objects.last().site_slug}),
+            status_code=302,
+            target_status_code=200)
+        self.assertNotEqual(modified, Site.test_objects.last().modified)
 
     def test_unsuccessful_site_update(self):
         """Tests that update is unsuccessful if some/all data invalid"""
@@ -44,19 +50,25 @@ class UpdateSiteTestCase(TestCase):
             kwargs={'site_slug': self.site.site_slug}), {})
         self.assertFormError(response, 'site_form', 'site_name',
                              'This field is required.')
-        self.assertFalse(response.context['updated'])
 
     def test_passive_update(self):
         """Tests that submitting prepopulated form as-is changes nothing"""
+        site = Site.test_objects.create_site('reaky Creek')
+        modified = site.modified
+
         response = self.client.post(reverse(
             'streamwebs:update_site',
-            kwargs={'site_slug': self.site.site_slug}), {
-                'site_name': 'Creaky Creek',
+            kwargs={'site_slug': site.site_slug}), {
+                'site_name': 'reaky Creek',
                 'location': 'POINT(-121.3846841 44.0612385)'})
 
-        self.assertTrue(response.context['updated'])
-        self.assertEqual(self.site.modified, response.context['modified_time'])
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            reverse('streamwebs:site',
+                    kwargs={'site_slug': Site.test_objects.last().site_slug}),
+            status_code=302,
+            target_status_code=200)
+        self.assertEqual(site.modified, modified)
 
     def test_view_with_not_logged_in_user(self):
         """Tests that user is redirected to login if they're not logged in"""

--- a/streamwebs_frontend/streamwebs/tests/views/test_update_site.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_update_site.py
@@ -59,10 +59,12 @@ class UpdateSiteTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_view_with_not_logged_in_user(self):
-        """Tests that the user can't update site if they're not logged in"""
+        """Tests that user is redirected to login if they're not logged in"""
         self.client.logout()
         response = self.client.get(reverse('streamwebs:update_site',
                                    kwargs={'site_slug': self.site.site_slug}))
-
-        self.assertContains(response, 'You must be logged in to edit a site.')
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response, reverse('streamwebs:login') + '?next=' + reverse(
+                'streamwebs:update_site',
+                kwargs={'site_slug': self.site.site_slug}), status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_water_quality_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_water_quality_edit_view.py
@@ -1,7 +1,7 @@
 from django.test import Client, TestCase
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
-from streamwebs.models import Site, School
+from streamwebs.models import Site, School, Water_Quality
 
 
 class AddWaterQualityTestCase(TestCase):
@@ -35,7 +35,6 @@ class AddWaterQualityTestCase(TestCase):
             'fish_present',
             'This field is required.'
         )
-        self.assertFalse(response.context['added'])
 
     def test_view_with_good_data(self):
         """
@@ -146,11 +145,13 @@ class AddWaterQualityTestCase(TestCase):
                 'water_quality-MAX_NUM_FORMS': '4'
             }
         )
-        self.assertTemplateUsed(
-            response, 'streamwebs/datasheets/water_quality.html'
-        )
-        self.assertTrue(response.context['added'])
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            reverse('streamwebs:water_quality',
+                    kwargs={'site_slug': site.site_slug,
+                            'data_id': Water_Quality.test_objects.last().id}),
+            status_code=302,
+            target_status_code=200)
 
     def test_view_with_not_logged_in_user(self):
         """

--- a/streamwebs_frontend/streamwebs/tests/views/test_water_quality_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_water_quality_edit_view.py
@@ -164,5 +164,10 @@ class AddWaterQualityTestCase(TestCase):
                 kwargs={'site_slug': site.site_slug}
             )
         )
-        self.assertContains(response, 'You must be logged in to submit data.')
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:water_quality_edit',
+                        kwargs={'site_slug': site.site_slug})),
+            status_code=302,
+            target_status_code=200)

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -319,7 +319,7 @@ def macroinvertebrate_edit(request, site_slug):
 
 def riparian_transect_view(request, site_slug, data_id):
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
-    transect = RiparianTransect.objects.filter(site_id=site.id).get(id=data_id)
+    transect = RiparianTransect.objects.get(id=data_id)
     zones = TransectZone.objects.filter(transect_id=transect)
 
     # Invoking the database by evaluating the queryset before passing it to the
@@ -341,7 +341,6 @@ def riparian_transect_edit(request, site_slug):
     """
     The view for the submission of a new riparian transect data sheet.
     """
-    added = False
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
     transect = RiparianTransect()
     TransectZoneInlineFormSet = inlineformset_factory(
@@ -366,7 +365,14 @@ def riparian_transect_edit(request, site_slug):
                 zone.transect = transect                # assign the transect
                 zone.save()                             # save the zone obj
 
-            added = True
+            messages.success(
+                request,
+                'You have successfully added a new riparian transect ' +
+                'data sheet.')
+
+            return redirect(reverse('streamwebs:riparian_transect',
+                                    kwargs={'site_slug': site.site_slug,
+                                            'data_id': transect.id}))
 
     else:
         zone_formset = TransectZoneInlineFormSet(instance=transect)
@@ -376,7 +382,7 @@ def riparian_transect_edit(request, site_slug):
         request,
         'streamwebs/datasheets/riparian_transect_edit.html', {
             'transect_form': transect_form, 'zone_formset': zone_formset,
-            'added': added, 'site': site
+            'site': site
         }
     )
 

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -35,6 +35,7 @@ def index(request):
     return render(request, 'streamwebs/index.html', {})
 
 
+@login_required
 def create_site(request):
     created = False
 

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -648,6 +648,7 @@ def water_quality(request, site_slug, data_id):
     )
 
 
+@login_required
 def water_quality_edit(request, site_slug):
     """ Add a new water quality sample """
     added = False       # flag for the page to see if we added a sample

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -732,12 +732,12 @@ def soil_survey(request, site_slug, data_id):
     )
 
 
+@login_required
 def soil_survey_edit(request, site_slug):
     """
     The view for the submistion of a new Soil Survey (data sheet)
     """
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
-    added = False
     soil_form = SoilSurveyForm()
 
     if request.method == 'POST':
@@ -747,7 +747,6 @@ def soil_survey_edit(request, site_slug):
             soil = soil_form.save(commit=False)
             soil.site = site
             soil.save()
-            added = True
             messages.success(
                 request, 'You have successfully submitted a new soil survey.'
             )
@@ -758,7 +757,6 @@ def soil_survey_edit(request, site_slug):
     return render(
         request, 'streamwebs/datasheets/soil_edit.html', {
             'soil_form': soil_form,
-            'added': added,
             'site': site
         }
     )

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -655,7 +655,6 @@ def water_quality(request, site_slug, data_id):
 @login_required
 def water_quality_edit(request, site_slug):
     """ Add a new water quality sample """
-    added = False       # flag for the page to see if we added a sample
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
     WQInlineFormSet = inlineformset_factory(
         Water_Quality, WQ_Sample,
@@ -677,10 +676,14 @@ def water_quality_edit(request, site_slug):
             for sample in allSamples:
                 sample.water_quality = water_quality
                 sample.save()
-            added = True
-            # ugly way of resetting the form if successful form submission
-            wq_form = WQForm()
-            sample_formset = WQInlineFormSet(instance=Water_Quality())
+            messages.success(
+                request,
+                'You have successfully added a new water quality ' +
+                'data sheet.')
+            return redirect(reverse('streamwebs:water_quality',
+                            kwargs={'site_slug': site.site_slug,
+                                    'data_id': water_quality.id}))
+
     else:
         # blank forms for normal page render
         wq_form = WQForm()
@@ -689,7 +692,6 @@ def water_quality_edit(request, site_slug):
         request, 'streamwebs/datasheets/water_quality.html',
         {
             'editable': True,
-            'added': added,
             'site': site,
             'wq_form': wq_form,
             'sample_formset': sample_formset,

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -394,6 +394,7 @@ def canopy_cover_view(request, site_slug, data_id):
         )
 
 
+@login_required
 def canopy_cover_edit(request, site_slug):
     """
     The view for the submission of a new canopy cover data sheet.

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -480,7 +480,6 @@ def camera_point_view(request, site_slug, cp_id):
 @login_required
 def add_camera_point(request, site_slug):
     """Add new CP to site + 3 PPs and respective photos"""
-    added = False
     site = Site.objects.get(site_slug=site_slug)
     camera = CameraPoint()
     PhotoPointInlineFormset = inlineformset_factory(  # photo point formset (3)
@@ -518,8 +517,13 @@ def add_camera_point(request, site_slug):
                                       date=ppi.date)
                 ppi.save()
 
-            added = True
+            messages.success(
+                request,
+                'You have successfully added a new camera point.')
 
+            return redirect(reverse('streamwebs:camera_point',
+                                    kwargs={'site_slug': site.site_slug,
+                                            'cp_id': camera.id}))
     else:
         camera_form = CameraPointForm()
         pp_formset = PhotoPointInlineFormset(instance=camera)
@@ -533,7 +537,6 @@ def add_camera_point(request, site_slug):
             'camera_form': camera_form,
             'pp_formset': pp_formset,
             'ppi_formset': ppi_formset,
-            'added': added,
             'site': site
         }
     )
@@ -592,7 +595,6 @@ def view_pp_and_add_img(request, site_slug, cp_id, pp_id):
 @login_required
 def add_photo_point(request, site_slug, cp_id):
     """Add new PP to existing CP + respective photo(s)"""
-    added = False
     site = Site.objects.get(site_slug=site_slug)
     cp = CameraPoint.objects.get(id=cp_id)
     photo_point = PhotoPoint()
@@ -619,7 +621,15 @@ def add_photo_point(request, site_slug, cp_id):
                 ppi.photo_point = photo_point
                 ppi.save()
 
-            added = True
+            messages.success(
+                request,
+                'You have successfully added a new camera point.')
+
+            return redirect(reverse('streamwebs:photo_point',
+                                    kwargs={'site_slug': site.site_slug,
+                                            'cp_id': cp.id,
+                                            'pp_id': photo_point.id}))
+
     else:
         pp_form = PhotoPointForm()
         ppi_formset = PPImageInlineFormset(instance=photo_point)
@@ -631,7 +641,6 @@ def add_photo_point(request, site_slug, cp_id):
             'cp': cp,
             'pp_form': pp_form,
             'ppi_formset': ppi_formset,
-            'added': added,
         }
     )
 

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -188,7 +188,6 @@ def user_login(request):
         # url
         if user:
             login(request, user)
-            print("redirect_to is" + redirect_to)
             if redirect_to != '':
                 return HttpResponseRedirect(redirect_to)
             else:

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -95,7 +95,6 @@ def site(request, site_slug):
 
 @login_required
 def update_site(request, site_slug):
-    updated = False
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
     temp = copy.copy(site)
 
@@ -111,7 +110,10 @@ def update_site(request, site_slug):
                 site.modified = timezone.now()
                 site.save()
 
-            updated = True
+            messages.success(request, 'You have successfully updated ' +
+                             site.site_name + '.')
+            return redirect(reverse('streamwebs:site',
+                                    kwargs={'site_slug': site.site_slug}))
 
     else:
         site_form = SiteForm(initial={'site_name': site.site_name,
@@ -123,7 +125,6 @@ def update_site(request, site_slug):
         'site': site,
         'site_form': site_form,
         'modified_time': site.modified,
-        'updated': updated
     })
 
 

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -336,6 +336,7 @@ def riparian_transect_view(request, site_slug, data_id):
         )
 
 
+@login_required
 def riparian_transect_edit(request, site_slug):
     """
     The view for the submission of a new riparian transect data sheet.

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -92,6 +92,7 @@ def site(request, site_slug):
     })
 
 
+@login_required
 def update_site(request, site_slug):
     updated = False
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
@@ -173,16 +174,21 @@ def register(request):
 
 
 def user_login(request):
+    redirect_to = request.POST.get('next', '')
     if request.method == 'POST':
         username = request.POST['username']
         password = request.POST['password']
         user = authenticate(username=username, password=password)
-
         if user:
             login(request, user)
-            return HttpResponseRedirect('/')
+            print("redirect_to is" + redirect_to)
+            if redirect_to != '':
+                return HttpResponseRedirect(redirect_to)
+            else:
+                return redirect(reverse('streamwebs:index'))
         else:
-            return HttpResponse(_('Invalid credentials'))
+            messages.error(request, 'Invalid username or password.')
+            return redirect(reverse('streamwebs:login'))
     else:
         return render(request, 'streamwebs/login.html')
 

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -465,6 +465,7 @@ def camera_point_view(request, site_slug, cp_id):
     )
 
 
+@login_required
 def add_camera_point(request, site_slug):
     """Add new CP to site + 3 PPs and respective photos"""
     added = False
@@ -576,6 +577,7 @@ def view_pp_and_add_img(request, site_slug, cp_id, pp_id):
     )
 
 
+@login_required
 def add_photo_point(request, site_slug, cp_id):
     """Add new PP to existing CP + respective photo(s)"""
     added = False

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -389,7 +389,7 @@ def riparian_transect_edit(request, site_slug):
 
 def canopy_cover_view(request, site_slug, data_id):
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
-    canopy_cover = Canopy_Cover.objects.filter(site_id=site.id).get(id=data_id)
+    canopy_cover = Canopy_Cover.objects.get(id=data_id)
     cardinals = CC_Cardinal.objects.filter(canopy_cover_id=canopy_cover)
 
     return render(
@@ -406,7 +406,6 @@ def canopy_cover_edit(request, site_slug):
     """
     The view for the submission of a new canopy cover data sheet.
     """
-    added = False
     site = Site.objects.filter(active=True).get(site_slug=site_slug)
     canopy_cover = Canopy_Cover()
     CardinalInlineFormSet = inlineformset_factory(
@@ -434,7 +433,14 @@ def canopy_cover_edit(request, site_slug):
                 cardinal.canopy_cover = canopy_cover
                 cardinal.save()
 
-            added = True
+            messages.success(
+                request,
+                'You have successfully added a new canopy cover ' +
+                'data sheet.')
+
+            return redirect(reverse('streamwebs:canopy_cover',
+                                    kwargs={'site_slug': site.site_slug,
+                                            'data_id': canopy_cover.id}))
 
     else:
         cardinal_formset = CardinalInlineFormSet(instance=canopy_cover)
@@ -445,7 +451,7 @@ def canopy_cover_edit(request, site_slug):
         'streamwebs/datasheets/canopy_cover_edit.html', {
             'canopy_cover_form': canopy_cover_form,
             'cardinal_formset': cardinal_formset,
-            'added': added, 'site': site
+            'site': site
         }
     )
 

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -84,7 +84,6 @@ TEMPLATES = [
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
-                'django.core.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.i18n',

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -84,6 +84,7 @@ TEMPLATES = [
             'context_processors': [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
+                'django.core.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.i18n',
@@ -144,6 +145,7 @@ USE_L10N = True
 
 USE_TZ = False
 
+LOGIN_URL = 'streamwebs:login'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -160,19 +160,6 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder'
 )
 
-# List of schools
-# Format: each school listed in the SCHOOL_CHOICES tuple should be a tuple of
-# two elements, the first being the value to be set on the user model and the
-# second being the human-readable name. Below is a temporary entry that
-# demonstrates how each school should be formatted. Keep in mind that if this
-# list is empty, the testing of the "register" page in-browser will be limited
-# since successful registration requires the selection of a school that
-# actually exists in SCHOOL_CHOICES.
-SCHOOL_CHOICES = (
-    # Example:
-    ('a', 'School A'),
-)
-
 LANGUAGES = [
     ('en-us', 'English'),
     ('es', 'Español'),


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #184 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] After login, user is redirected to the last page they were on instead of the home page, unless there was no previous page (they accessed login by directly entering the login url)
- [X] When unauthenticated user tries to access restricted url (i.e., new datasheet or new site or site update), they immediately get the login page instead instead of a "you must log in" page; after they log in, they then are redirected immediately to the original page (data entry) they requested instead of the home page
- [X] After submitting a new valid data sheet/a new site/an updated site, the user is redirected to the view for the datasheet/site and sees a "success" flash message

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

Running tests:
1. ``docker-compose run web bash``
2. ``cd streamwebs_frontend``
3. ``python manage.py test streamwebs/tests/*``

In the browser:
4. ``python manage.py createsuperuser``
5. ``docker-compose up``
6. Go straight to localhost:8000/streamwebs/login; enter bad creds and then good creds with your superuser creds.
7. Go to localhost:8000/streamwebs and click around. Try to submit data sheets (go to /sites/[site_slug] and scroll to the bottom) or add/update a site (/sites/new and /sites/[site_slug]/update) while not logged in.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->
Recap:
- Bad creds: Back to login with a "bad creds" flash message.
- Good creds: Redirect back to previous page. If there wasn't a previous page (user went straight to login url instead of clicking the button from some other page), user redirected back to home instead
- Trying to add data when not logged in: Redirected straight to login, then back again to the requested data entry page immediately after successful login
- Successfully adding data when logged in: redirected to the view that summarizes what they input
```
[root@8a81230c87bf streamwebs_frontend]# python manage.py test streamwebs/tests/*
Creating test database for alias 'default'...
.........................................................................................................................................................................................
----------------------------------------------------------------------
Ran 185 tests in 6.188s

OK
Destroying test database for alias 'default'...
```