### PR TITLE
Set datasheets to only show the selected site.

### DIFF
--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -90,7 +90,7 @@ class WQForm(forms.ModelForm):
                 forms.Textarea(attrs={'class': 'materialize-textarea'})
         }
         fields = (
-            'site', 'date', 'DEQ_dq_level', 'school',
+            'date', 'DEQ_dq_level', 'school',
             'latitude', 'longitude', 'fish_present', 'live_fish',
             'dead_fish', 'water_temp_unit', 'air_temp_unit', 'notes'
         )
@@ -140,7 +140,7 @@ class WQSampleFormReadOnly(WQSampleForm):
 class Canopy_Cover_Form(forms.ModelForm):
     class Meta:
         model = Canopy_Cover
-        fields = ('school', 'date_time', 'site', 'weather', 'est_canopy_cover')
+        fields = ('school', 'date_time', 'weather', 'est_canopy_cover')
 
 
 class CC_Cardinal_Form(forms.ModelForm):
@@ -162,7 +162,7 @@ class RiparianTransectForm(forms.ModelForm):
 
     class Meta:
         model = RiparianTransect
-        fields = ('school', 'date_time', 'weather', 'site', 'slope', 'notes')
+        fields = ('school', 'date_time', 'weather', 'slope', 'notes')
 
 
 class PhotoPointImageForm(forms.ModelForm):

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -5,14 +5,17 @@
 {% block title %}{% trans "Add Canopy Cover Survey" %}{% endblock %}
 {% block body_title %}{% trans "Add Canopy Cover Survey" %}{% endblock %}
 {% block content %}
-
     <form id='canopy_cover_form' method='post'>
         {% csrf_token %}
         <table> <!-- main cc info table -->
             <tr>{{ canopy_cover_form.non_field_errors }}</tr>
             <tr>
                 <th align='left'>{{ canopy_cover_form.site.label }}</th>
-                <td>{{ canopy_cover_form.site }}</td>
+                <td>
+                    <select>
+                        <option selected>{{ site.site_name }}</option>
+                    </select>
+                </td>
                 <td>{{ canopy_cover_form.site.errors }}</td>
             </tr>
             <tr>
@@ -56,4 +59,13 @@
 
     <input type='submit', name='submit', value='Submit' />
     </form>
+{% endblock %}
+
+{% block scripts %}
+    <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/css/materialize.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+    <script>
+    $('select').material_select();
+    </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -5,19 +5,22 @@
 {% block title %}{% trans "Add Canopy Cover Survey" %}{% endblock %}
 {% block body_title %}{% trans "Add Canopy Cover Survey" %}{% endblock %}
 {% block content %}
+
+{% if user.is_authenticated %}
+    {% if added %}
+        <strong> "You have successfully submitted your Canopy Cover Survey." </strong>
+
+    {% else %}
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site_detail' '{{site.site_slug}}">
+            {{site.site_name}}
+        </a>
+    </h3>
+    <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
     <form id='canopy_cover_form' method='post'>
         {% csrf_token %}
         <table> <!-- main cc info table -->
             <tr>{{ canopy_cover_form.non_field_errors }}</tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.site.label }}</th>
-                <td>
-                    <select>
-                        <option selected>{{ site.site_name }}</option>
-                    </select>
-                </td>
-                <td>{{ canopy_cover_form.site.errors }}</td>
-            </tr>
             <tr>
                 <th align='left'>{{ canopy_cover_form.school.label }}</th>
                 <td>{{ canopy_cover_form.school }}</td>
@@ -57,7 +60,7 @@
 
         </table> <!-- end canopy cover -->
 
-    <input type='submit', name='submit', value='Submit' />
+    <input type='submit' name='submit' value='Submit' />
     </form>
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -21,11 +21,6 @@
     {% csrf_token %}
     <table> <!-- main cc info table -->
         <tr>{{ canopy_cover_form.non_field_errors }}</tr>
-        <tr style="display: none">
-            <th align='left'>{{ canopy_cover_form.site.label }}</th>
-            <td>{{ canopy_cover_form.site }}</td>
-            <td>{{ canopy_cover_form.site.errors }}</td>
-        </tr>
         <tr>
             <th align='left'>{{ canopy_cover_form.school.label }}</th>
             <td>{{ canopy_cover_form.school }}</td>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -7,68 +7,80 @@
 {% block content %}
 
 {% if user.is_authenticated %}
-    {% if added %}
-        <strong> "You have successfully submitted your Canopy Cover Survey." </strong>
+{% if added %}
+<strong> "You have successfully submitted your Canopy Cover Survey." </strong>
 
-    {% else %}
-    <h3 align="center">
-        <a href="{% url 'streamwebs:site_detail' '{{site.site_slug}}">
-            {{site.site_name}}
-        </a>
-    </h3>
-    <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
-    <form id='canopy_cover_form' method='post'>
-        {% csrf_token %}
-        <table> <!-- main cc info table -->
-            <tr>{{ canopy_cover_form.non_field_errors }}</tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.school.label }}</th>
-                <td>{{ canopy_cover_form.school }}</td>
-                <td>{{ canopy_cover_form.school.errors }}</td>
-            </tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.date_time.label }}</th>
-                <td>{{ canopy_cover_form.date_time }}</td>
-                <td>{{ canopy_cover_form.date_time.errors }}</td>
-            </tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.weather.label }}</th>
-                <td>{{ canopy_cover_form.weather }}</td>
-                <td>{{ canopy_cover_form.weather.errors }}</td>
-            </tr>
+{% else %}
+<h3 align="center">
+    <a href="{% url 'streamwebs:site' site.site_slug %}">
+        {{ site.site_name }}
+    </a>
+</h3>
+<h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
+<form id='canopy_cover_form' method='post'>
+    {% csrf_token %}
+    <table> <!-- main cc info table -->
+        <tr>{{ canopy_cover_form.non_field_errors }}</tr>
+        <tr style="display: none">
+            <th align='left'>{{ canopy_cover_form.site.label }}</th>
+            <td>{{ canopy_cover_form.site }}</td>
+            <td>{{ canopy_cover_form.site.errors }}</td>
+        </tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.school.label }}</th>
+            <td>{{ canopy_cover_form.school }}</td>
+            <td>{{ canopy_cover_form.school.errors }}</td>
+        </tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.date_time.label }}</th>
+            <td>{{ canopy_cover_form.date_time }}</td>
+            <td>{{ canopy_cover_form.date_time.errors }}</td>
+        </tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.weather.label }}</th>
+            <td>{{ canopy_cover_form.weather }}</td>
+            <td>{{ canopy_cover_form.weather.errors }}</td>
+        </tr>
 
-            {{ cardinal_formset.management_form }}
+        {{ cardinal_formset.management_form }}
 
-            <table>
+        <table>
             {% for cardinal_form in cardinal_formset %}
-                <tr>
-                    <th></th>
-                    <td>{{ cardinal_form.direction.errors }}</td>
-                </tr>
-                <tr>
-                    {{ cardinal_form.as_table }}
-                </tr>
-            {% endfor %}
-            </table>
-
-            <tr></tr>
             <tr>
-                <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
-                <td>{{ canopy_cover_form.est_canopy_cover }}</td>
-                <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
+                <th></th>
+                <td>{{ cardinal_form.direction.errors }}</td>
             </tr>
+            <tr>
+                {{ cardinal_form.as_table }}
+            </tr>
+            {% endfor %}
+        </table>
 
-        </table> <!-- end canopy cover -->
+        <tr></tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
+            <td>{{ canopy_cover_form.est_canopy_cover }}</td>
+            <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
+        </tr>
 
-    <input type='submit' name='submit' value='Submit' />
-    </form>
+    </table> <!-- end canopy cover -->
+
+    <input type='submit' name='submit' value='Submit'/>
+</form>
+{% endif %}
+
+{% else %}
+<p>{% trans "You must be logged in to submit data." %}</p>
+<a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
+{% endif %}
+
 {% endblock %}
 
 {% block scripts %}
-    <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/css/materialize.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
-    <script>
+<link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/css/materialize.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+<script>
     $('select').material_select();
-    </script>
+</script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -5,6 +5,12 @@
 {% block title %}{% trans "View Canopy Cover Survey" %}{% endblock %}
 {% block body_title %}{% trans "Canopy Cover Survey: " %}{{ canopy_cover.date_time }}{% endblock %}
 {% block content %}
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
+    <h4 align="center">Canopy Cover data: {{ canopy_cover.date_time|date:"m-d-Y" }}</h4>
     <div>
         <table>
             <tr>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -20,8 +20,12 @@
         <strong>{% trans "You have successfully submitted your Macroinvertebrate data sheet." %}.</strong>
 
         {% else %}
-        <h3 align="center">{{ site.site_name }}</h3>
-        <h4 align="center">{% trans "New macroinvertebrate sampling" %}</h4>
+            <h3 align="center">
+                <a href="{% url 'streamwebs:site_detail' '{{site.site_slug}}">
+                    {{site.site_name}}
+                </a>
+            </h3>
+            <h4 align="center">{% trans 'New Macroinvertebrate Sampling' %}</h4>
         <form id='macro_form' method='post' action='{{ request.path }}'>
             {% csrf_token %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -21,8 +21,8 @@
 
         {% else %}
             <h3 align="center">
-                <a href="{% url 'streamwebs:site_detail' '{{site.site_slug}}">
-                    {{site.site_name}}
+                <a href="{% url 'streamwebs:site' site.site_slug %}">
+                    {{ site.site_name }}
                 </a>
             </h3>
             <h4 align="center">{% trans 'New Macroinvertebrate Sampling' %}</h4>
@@ -137,7 +137,7 @@
                 </div>  <!-- end tolerant -->
             </div> <!-- end macros row -->
 
-            <input class="waves-effect waves-light btn" type='submit', name='submit', value='Submit' />
+            <input class="waves-effect waves-light btn" type='submit' name='submit' value='Submit' />
         </form>
         {% endif %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load filters %}
 {% block title %}{% trans "View Macroinvertebrates Data" %}{% endblock %}
+{% block body_title %}{% trans "Macroinvertebrates: " %}{{ data.date_time|date:"m-d-Y" }}{% endblock %}
  
 {% block scripts %}
     <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -24,7 +25,11 @@
         <strong>{{ message }}</strong>
         {% endfor %}
     {% endif %}
-    <h3 align="center">{{ data.site.site_name }}</h3>
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
     <h4 align="center">Macroinvertebrate data: {{ data.date_time|date:"m-d-Y" }}</h4>
    
     <div class="row">

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -6,6 +6,17 @@
 {% block body_title %}{% trans "Riparian Transect" %}{% endblock %}
 {% block content %}
 
+{% if user.is_authenticated %}
+{% if added %}
+    <strong> "You have successfully submitted your Canopy Cover Survey." </strong>
+
+{% else %}
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
+    <h4 align="center">{% trans 'New Riparian Transect Sampling' %}</h4>
     <form id='rip_trans_form' method='post'>
         {% csrf_token %}
         <table> <!-- main transect info table -->
@@ -19,11 +30,6 @@
                 <th align='left'>{{ transect_form.date_time.label }}</th>
                 <td>{{ transect_form.date_time }}</td>
                 <td>{{ transect_form.date_time.errors }}</td>
-            </tr>
-            <tr>
-                <th align='left'>{{ transect_form.site.label }}</th>
-                <td>{{ transect_form.site }}</td>
-                <td>{{ transect_form.site.errors }}</td>
             </tr>
             <tr>
                 <th align='left'>{{ transect_form.slope.label }}</th>
@@ -74,6 +80,12 @@
 
     <input type='submit' name='submit' value='Submit' />
     </form>
+{% endif %}
+
+{% else %}
+    <p>{% trans "You must be logged in to submit data." %}</p>
+    <a href='/streamwebs/login/'>{% trans "Log in here." %}</a>
+{% endif %}
 
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -72,7 +72,7 @@
             </tr>
         </table> <!-- end main transect info table -->
 
-    <input type='submit', name='submit', value='Submit' />
+    <input type='submit' name='submit' value='Submit' />
     </form>
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_view.html
@@ -3,8 +3,14 @@
 {% load i18n %}
 {% load filters %}
 {% block title %}{% trans "View Riparian Transect Data" %}{% endblock %}
-{% block body_title %}{% trans "Riparian Transect: " %}{{ transect.date_time }}{% endblock %}
+{% block body_title %}{% trans "Riparian Transect: " %}{{ transect.date_time|date:"m-d-Y" }}{% endblock %}
 {% block content %}
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
+    <h4 align="center">Riparian Transect data: {{ transect.date_time|date:"m-d-Y" }}</h4>
     <div>
         <table>
             <tr>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -39,8 +39,9 @@
                             {{ wq_form.site.label }}
 
                             <!-- TODO: Style errors -->
-                            {{ wq_form.site.errors | striptags }}
-                            {{ wq_form.site }}
+                            <select>
+                                <option selected>{{ site.site_name }}</option>
+                            </select>
                         </div>
                     </div>
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -39,6 +39,7 @@
         <form id="water_quality_form" action="" method="POST">
             {% csrf_token %}
             <div class="infogroup">
+                <p>{{ wq_form.site.errors | striptags }}</p>
                 <div class="row">
                     <div class="col s6">
                         <div class="input-field">
@@ -48,13 +49,6 @@
                             {{ wq_form.date }}
                         </div>
                     </div>
-                </div>
-
-                <div class="input-field" style="display: none">
-                    {{ wq_form.site.label }}
-
-                    {{ wq_form.site.errors | striptags }}
-                    {{ wq_form.site }}
                 </div>
                 <div class="row">
                     <div class="col s6">

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -30,27 +30,22 @@
     {% endfor %} -->
 
     <div class="container">
+        <h3 align="center">
+            <a href="{% url 'streamwebs:site_detail' '{{site.site_slug}}">
+                {{site.site_name}}
+            </a>
+        </h3>
+        <h4 align="center">{% trans 'New Water Quality Sampling' %}</h4>
         <form id="water_quality_form" action="" method="POST">
             {% csrf_token %}
             <div class="infogroup">
                 <div class="row">
                     <div class="col s6">
                         <div class="input-field">
-                            {{ wq_form.site.label }}
+                            <label for="{{ wq_form.date.id_for_label }}">{{ wq_form.date.label }}</label>
 
-                            <!-- TODO: Style errors -->
-                            <select>
-                                <option selected>{{ site.site_name }}</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ wq_form.DEQ_dq_level.label }}
-
-                            {{ wq_form.DEQ_dq_level.errors | striptags }}
-                            {{ wq_form.DEQ_dq_level }}
+                            {{ wq_form.date.errors | striptags }}
+                            {{ wq_form.date }}
                         </div>
                     </div>
                 </div>
@@ -66,10 +61,10 @@
                     </div>
                     <div class="col s6">
                         <div class="input-field">
-                            <label for="{{ wq_form.date.id_for_label }}">{{ wq_form.date.label }}</label>
+                            {{ wq_form.DEQ_dq_level.label }}
 
-                            {{ wq_form.date.errors | striptags }}
-                            {{ wq_form.date }}
+                            {{ wq_form.DEQ_dq_level.errors | striptags }}
+                            {{ wq_form.DEQ_dq_level }}
                         </div>
                     </div>
                 </div>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -31,7 +31,7 @@
 
     <div class="container">
         <h3 align="center">
-            <a href="{% url 'streamwebs:site_detail' '{{site.site_slug}}">
+            <a href="{% url 'streamwebs:site' site.site_slug %}">
                 {{site.site_name}}
             </a>
         </h3>
@@ -50,6 +50,12 @@
                     </div>
                 </div>
 
+                <div class="input-field" style="display: none">
+                    {{ wq_form.site.label }}
+
+                    {{ wq_form.site.errors | striptags }}
+                    {{ wq_form.site }}
+                </div>
                 <div class="row">
                     <div class="col s6">
                         <div class="input-field">

--- a/streamwebs_frontend/streamwebs/tests/forms/test_cc_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_cc_form.py
@@ -8,7 +8,6 @@ class Canopy_Cover_Form_TestCase(TestCase):
         self.expected_fields = (
             'school',
             'date_time',
-            'site',
             'weather',
             'est_canopy_cover'
         )

--- a/streamwebs_frontend/streamwebs/tests/forms/test_transect_forms.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_transect_forms.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from django.test import TestCase
 from streamwebs.forms import TransectZoneForm, RiparianTransectForm
 
@@ -31,14 +32,12 @@ class RiparianTransectFormTestCase(TestCase):
             'school',
             'date_time',
             'weather',
-            'site',
             'slope',
             'notes',
         )
 
         self.required_fields = (
             'school',
-            'site'
         )
 
     def test_form_fields_exist(self):

--- a/streamwebs_frontend/streamwebs/tests/forms/test_wq_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_wq_form.py
@@ -7,7 +7,6 @@ class WQFormTestCase(TestCase):
 
     def setUp(self):
         self.expected_fields = (
-            'site',
             'date',
             'DEQ_dq_level',
             'school',

--- a/streamwebs_frontend/streamwebs/views.py
+++ b/streamwebs_frontend/streamwebs/views.py
@@ -355,8 +355,8 @@ def riparian_transect_edit(request, site_slug):
         transect_form = RiparianTransectForm(data=request.POST)
 
         if (zone_formset.is_valid() and transect_form.is_valid()):
-
             transect = transect_form.save()             # save form to object
+            transect.site = site
             transect.save()                             # save object
 
             zones = zone_formset.save(commit=False)     # save forms to objs
@@ -425,6 +425,7 @@ def canopy_cover_edit(request, site_slug):
         if (cardinal_formset.is_valid() and canopy_cover_form.is_valid()):
 
             canopy_cover = canopy_cover_form.save()
+            canopy_cover.site = site
             canopy_cover.save()
 
             cardinals = cardinal_formset.save(commit=False)
@@ -692,6 +693,7 @@ def water_quality_edit(request, site_slug):
         wq_form = WQForm(data=request.POST)
         if (sample_formset.is_valid() and wq_form.is_valid()):
             water_quality = wq_form.save()   # save form to object
+            water_quality.site = site
             water_quality.save()             # save object to db
             allSamples = sample_formset.save(commit=False)
             for sample in allSamples:


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes point 4 of #187.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Set canopy cover, riparian transect, and water quality add/edit forms to limit site selection to the one the user is currently on.
- [ ] Fix the photopoint and camerapoint add forms' site select, and limit to current site.

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Look at the canopy cover, riparian transect, and water quality datasheets.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

The site fields will be limited to the current site.

@osuosl/devs
