### PR TITLE
add extra "admin" tab in navigation bar viewable only to admins

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -2,5 +2,5 @@
 
 # run migrations then test
 python streamwebs_frontend/manage.py makemigrations
-python streamwebs_frontend/manage.py migrate
+python streamwebs_frontend/manage.py migrate --noinput
 python streamwebs_frontend/manage.py test streamwebs_frontend/streamwebs/tests/*

--- a/streamwebs_frontend/streamwebs/__init__.py
+++ b/streamwebs_frontend/streamwebs/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'streamwebs.apps.StreamwebsConfig'

--- a/streamwebs_frontend/streamwebs/apps.py
+++ b/streamwebs_frontend/streamwebs/apps.py
@@ -3,5 +3,9 @@ from __future__ import unicode_literals
 from django.apps import AppConfig
 
 
-class StreamwebsApiConfig(AppConfig):
+class StreamwebsConfig(AppConfig):
     name = 'streamwebs'
+    print("in the config class.")
+
+    def ready(self):
+        import signals  # NOQA

--- a/streamwebs_frontend/streamwebs/apps.py
+++ b/streamwebs_frontend/streamwebs/apps.py
@@ -5,7 +5,6 @@ from django.apps import AppConfig
 
 class StreamwebsConfig(AppConfig):
     name = 'streamwebs'
-    print("in the config class.")
 
     def ready(self):
         import signals  # NOQA

--- a/streamwebs_frontend/streamwebs/signals.py
+++ b/streamwebs_frontend/streamwebs/signals.py
@@ -6,8 +6,6 @@ from django.db.models.signals import post_migrate
 
 @receiver(post_migrate)
 def init_groups_and_perms(sender, **kwargs):
-    print("inside init_groups_and_perms")
-
     content_type, created = ContentType.objects.get_or_create(
         app_label='streamwebs', model='unused')
 

--- a/streamwebs_frontend/streamwebs/signals.py
+++ b/streamwebs_frontend/streamwebs/signals.py
@@ -1,0 +1,29 @@
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.dispatch import receiver
+from django.db.models.signals import post_migrate
+
+
+@receiver(post_migrate)
+def init_groups_and_perms(sender, **kwargs):
+    print("inside init_groups_and_perms")
+
+    content_type, created = ContentType.objects.get_or_create(
+        app_label='streamwebs', model='unused')
+
+    can_upload, created = Permission.objects.get_or_create(
+        codename='can_upload_resources', name='can upload resources',
+        content_type=content_type)
+
+    can_promote, created = Permission.objects.get_or_create(
+        codename='can_promote_users', name='can promote other users',
+        content_type=content_type)
+
+    can_view_stats, created = Permission.objects.get_or_create(
+        codename='can_view_stats', name='can view site statistics',
+        content_type=content_type)
+
+    admin, created = Group.objects.get_or_create(name='admin')
+    if created:
+        admin.permissions.add(can_upload, can_promote, can_view_stats)
+        print("admin group created; permissions added")

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/navigation.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/navigation.html
@@ -12,6 +12,14 @@
           {% endfor %}
       </ul>
   </form>
+  
+  <ul id="admin-options" class="dropdown-content">
+    <!-- TODO: Real links -->
+    <li><a href="#!">View Site Statistics</a></li> 
+    <li><a href="#!">Upload Resources</a></li>
+    <li><a href="#!">Manage Users</a></li>
+  </ul>
+
   <nav class="cyan">
     <div class="nav-wrapper">
       <!--<a href="#!" class="brand-logo center">{% block body_title %}Streamwebs{% endblock %}</a>-->
@@ -33,10 +41,15 @@
         <li><a href="{% url 'streamwebs:index' %}">Resources</a></li>
 
         {% if user.is_authenticated %}
+            {% for group in user.groups.all %}
+                {% if group.name == 'admin' %}
+                    <li><a class="dropdown-button" href="#!" data-activates="admin-options">Administration<i class="material-icons right">arrow_drop_down</i></a></li>
+                {% endif %}
+            {% endfor %}
             <li><a href="{% url 'streamwebs:logout' %}">Logout</a></li>
         {% else %}
-        <li><a href="{% url 'streamwebs:login' %}?next={{ request.path }}">Login</a></li>
             <li><a href="{% url 'streamwebs:register' %}">Create Account</a></li>
+            <li><a href="{% url 'streamwebs:login' %}?next={{ request.path }}">Login</a></li>
         {% endif %}
       </ul>
     </div>

--- a/streamwebs_frontend/streamwebs/tests/perms/test_admin_group_perms.py
+++ b/streamwebs_frontend/streamwebs/tests/perms/test_admin_group_perms.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.contrib.auth.models import Group, Permission
+
+
+class AdminGroupPermissionsTestCase(TestCase):
+    def setUp(self):
+        self.admin, self.created = Group.objects.get_or_create(name='admin')
+        self.expected_perms = {
+            'can upload resources',
+            'can promote other users',
+            'can view site statistics',
+        }
+
+    def test_admin_group_already_exists(self):
+        admin, created = Group.objects.get_or_create(name='admin')
+        self.assertFalse(created)
+        self.assertEqual(admin.name, 'admin')
+
+    def test_perms_already_exist(self):
+        upload, created = Permission.objects.get_or_create(
+            name='can upload resources')
+        self.assertTrue(upload)
+        self.assertFalse(created)
+
+        promote, created = Permission.objects.get_or_create(
+            name='can promote other users')
+        self.assertTrue(promote)
+        self.assertFalse(created)
+
+        stats, created = Permission.objects.get_or_create(
+            name='can view site statistics')
+        self.assertTrue(stats)
+        self.assertFalse(created)
+
+    def test_admin_group_has_approp_perms(self):
+        admin_perms = self.admin.permissions.all()
+        for admin_perm in admin_perms:
+            self.assertIn(admin_perm.name, self.expected_perms)
+
+        self.assertEqual(len(self.expected_perms), len(admin_perms))

--- a/streamwebs_frontend/streamwebs/tests/views/test_index_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_index_view.py
@@ -1,9 +1,62 @@
-from django.test import TestCase
+from django.test import Client, TestCase
+from django.contrib.auth.models import User, Group
+from django.core.urlresolvers import reverse
 
 
 # Create your tests here.
 class IndexViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.reg_user = User.objects.create_user(
+            'reg',
+            'reg@example.com',
+            'regpassword'
+        )
+        self.admin = User.objects.create_user(
+            'admin',
+            'admin@example.com',
+            'adminpassword'
+        )
+        admins = Group.objects.get(name='admin')
+        self.admin.groups.set([admins])
+
     def test_index(self):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'streamwebs/index.html')
+
+    def test_regular_navigation_menu(self):
+        """When regular user logged in, can see standard tabs but not Admin."""
+        self.client.login(username='reg', password="regpassword")
+        response = self.client.get(reverse('streamwebs:index'))
+        self.assertNotContains(response, 'Administration')
+        self.assertNotContains(response, 'Login')
+        self.assertContains(response, 'Sites')
+        self.assertContains(response, 'Resources')
+        self.assertContains(response, 'Logout')
+        self.assertNotContains(response, 'Login')
+        self.assertNotContains(response, 'Create Account')
+        self.client.logout()
+
+    def test_admin_navigation_menu(self):
+        """When admin user logged in, can see standard tabs and Admin tab."""
+        self.client.login(username='admin', password="adminpassword")
+        response = self.client.get(reverse('streamwebs:index'))
+        self.assertContains(response, 'Administration')
+        self.assertNotContains(response, 'Login')
+        self.assertContains(response, 'Sites')
+        self.assertContains(response, 'Resources')
+        self.assertContains(response, 'Logout')
+        self.assertNotContains(response, 'Login')
+        self.assertNotContains(response, 'Create Account')
+        self.client.logout()
+
+    def test_anon_navigation_menu(self):
+        """When user not logged in, has Create Acct tab but no Admin tab."""
+        response = self.client.get(reverse('streamwebs:index'))
+        self.assertNotContains(response, 'Administration')
+        self.assertContains(response, 'Sites')
+        self.assertContains(response, 'Resources')
+        self.assertContains(response, 'Login')
+        self.assertNotContains(response, 'Logout')
+        self.assertContains(response, 'Create Account')


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #192 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Create permissions ("can upload resources," "can view site-wide statistics," "can promote other users") and an admin group with those permissions
- [x] Add "Admin" dropdown tab to the top menu bar that only users in the admin group can see/access

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

Running tests:
1. ``docker-compose run web bash``
2. ``cd streamwebs_frontend``
3. ``python manage.py test streamwebs/tests/*``

Viewing in-browser:
4. ``docker-compose up``
5. ``python manage.py createsuperuser``
6. Go to localhost:8000 in your browser; take note of the default navigation bar.
7. Logout and go to localhost:8000/admin in your browser; assign yourself to the ``admin`` group.
7. Go back to localhost:8000 and login again. Notice the navigation bar now has an extra "admin" tab that drops down to review three placeholder links for uploading resources, promoting other users to the admin group, and viewing the report page. 

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->
```
[root@ff504cd2ac7c streamwebs_frontend]# python manage.py test streamwebs/tests/*
Creating test database for alias 'default'...
admin group created; permissions added
...............................................................................................................................................................................................
----------------------------------------------------------------------
Ran 191 tests in 6.155s

OK
Destroying test database for alias 'default'...
```
Admin dropdown:
![admindrop](https://cloud.githubusercontent.com/assets/9158473/22168473/b9d5bda6-df21-11e6-9037-e3070d88a30b.png)
Admin tab:
![admintab](https://cloud.githubusercontent.com/assets/9158473/22168475/bcb41f4a-df21-11e6-8a79-c5f3748ea7a5.png)
Non-admin user (inc. superuser who is not in "admin" group)
![regular](https://cloud.githubusercontent.com/assets/9158473/22168463/af393774-df21-11e6-8dee-a69dc6147ec5.png)
Not logged in:
![anon](https://cloud.githubusercontent.com/assets/9158473/22168464/b362e458-df21-11e6-9c76-be10d8749078.png)

## Notes
- I placed the tests that test the presence of specific nav bar tabs in ``tests/views/test_index_view.py``; I can move it somewhere else if it makes more sense to do so?
- I added ``--noinput`` to the migrate command in the ``runtests.sh`` script. This is to avoid having Django ask whether or not we want stale content types and their related objects to be deleted (yes/no)-- Travis would stall and eventually error out because no input could be provided. The stale content type in question is ``unused``, a dummy model required for a dummy ``ContentType`` object I created, which is required to directly create ``Permission`` objects without creating an actual placeholder model. ``--noinput`` answers "no" by default, allowing ``unused`` and its related ``Permission``s to exist.
- In ``navigation.html``, I simply checked to see if the user was in the ``admin`` group, since if they are, they should have permissions that correspond to the three dropdown items anyway. For the actual promotion, statistics, and upload views, however, it would definitely make sense to check for those specific permissions. I can change what I have now this in anticipation of the event where some admins may lack one of the three established admin permissions, such as being able to promote another user?

@athai @Kennric @subnomo @LyonesGamer 