### PR TITLE
Fix graph widths and invalid values and ranges.

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/macros.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/macros.js
@@ -223,14 +223,16 @@ const useLineGraph = function useLineGraph() {
             name: name,
             values: formatted.map((d) => {
                 return {date: d.date, value: d[name]};
+            }).filter(d => {
+                return !isNaN(d.value);
             })
         };
     });
 
     const container = outerContainer;
     const margin = {top: 20, right: 200, bottom: 30, left: 40};
-    const width = (container.width() * 0.7) - margin.left - margin.right;
-    const height = 192 - margin.top - margin.bottom;
+    const width = container.width() - margin.left - margin.right;
+    const height = 250 - margin.top - margin.bottom;
 
     const x = d3.scaleTime()
         .range([0, width]);
@@ -238,20 +240,20 @@ const useLineGraph = function useLineGraph() {
     x.domain([
         date_range[0] !== 0 ? new Date(date_range[0]) :
             d3.min(formatted, (d) => {
-                return new Date(d.date)
+                return new Date(d.date) || new Date(new Date().getTime() - 86400)
             }),
         date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
             d3.max(formatted, (d) => {
-                return new Date(d.date)
+                return new Date(d.date) || new Date()
             }),
     ]);
     const y = d3.scaleLinear()
         .domain([0,
             d3.max(types, (c) => {
                 return d3.max(c.values, (d) => {
-                    return d.value
-                })
-            })
+                    return d.value || 1; // Prevent NaNs from spoiling the max
+                }) || 1
+            }) || 1
         ])
         .range([height, 0]);
     const z = d3.scaleOrdinal()

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/macros.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/macros.js
@@ -118,93 +118,98 @@ const useLineGraph = function useLineGraph() {
      * ]
      */
     formatted = formatted.map((x) => {
-      /*
-       * First we'll map the data to remove any extraneous values just in case,
-       * and to change the date to a string of just the date.
-       */
-      const key = x.date.toISOString().substring(0, 10);
+        /*
+         * First we'll map the data to remove any extraneous values just in case,
+         * and to change the date to a string of just the date.
+         */
+        const key = x.date.toISOString().substring(0, 10);
 
-      return {
-        date: key,
-        Sensitive: x.Sensitive,
-        'Somewhat Sensitive': x['Somewhat Sensitive'],
-        Tolerant: x.Tolerant,
-        Total: x.Total,
-      };
+        return {
+            date: key,
+            Sensitive: x.Sensitive,
+            'Somewhat Sensitive': x['Somewhat Sensitive'],
+            Tolerant: x.Tolerant,
+            Total: x.Total,
+        };
     }).reduce((prev, curr) => {
-      /*
-       * Next, we'll reduce it down to sums per day.
-       */
+        /*
+         * Next, we'll reduce it down to sums per day.
+         */
 
-      /*
-       * `data` here represents the existing data for the day we're looking at,
-       * if it exists. It contains all of the sums we've already calculated for
-       * this day, plus its own index in the list so we can find it later.
-       */
-      let data = prev.map((x, i) => { x['idx'] = i; return x; })
-                     .filter((x) => { return x.date === curr.date; });
-      if (data === [] || data.length === 0) {
         /*
-         * If this is the first data point we've found for this day, then we'll
-         * add it as it is to the list. Also add a `count` value so we can
-         * calculate the average from the sums.
+         * `data` here represents the existing data for the day we're looking at,
+         * if it exists. It contains all of the sums we've already calculated for
+         * this day, plus its own index in the list so we can find it later.
          */
-        prev.push({
-          date: curr.date,
-          Sensitive: curr.Sensitive,
-          'Somewhat Sensitive': curr['Somewhat Sensitive'],
-          Tolerant: curr.Tolerant,
-          Total: curr.Total,
-          count: 1,
-        });
-      } else {
-        /*
-         * Data now holds the existing data for the day. It's technically a list
-         * of size one, so get the first element out. Now modify the list to add
-         * our new values to the existing ones, and to increment the count.
-         */
-        data = data[0];
-        prev[data.idx] = {
-          date: curr.date,
-          Sensitive: data.Sensitive + curr.Sensitive,
-          'Somewhat Sensitive': data['Somewhat Sensitive'] + curr['Somewhat Sensitive'],
-          Tolerant: data.Tolerant + curr.Tolerant,
-          Total: data.Total + curr.Total,
-          count: data.count + 1,
+        let data = prev.map((x, i) => {
+            x['idx'] = i;
+            return x;
+        })
+            .filter((x) => {
+                return x.date === curr.date;
+            });
+        if (data === [] || data.length === 0) {
+            /*
+             * If this is the first data point we've found for this day, then we'll
+             * add it as it is to the list. Also add a `count` value so we can
+             * calculate the average from the sums.
+             */
+            prev.push({
+                date: curr.date,
+                Sensitive: curr.Sensitive,
+                'Somewhat Sensitive': curr['Somewhat Sensitive'],
+                Tolerant: curr.Tolerant,
+                Total: curr.Total,
+                count: 1,
+            });
+        } else {
+            /*
+             * Data now holds the existing data for the day. It's technically a list
+             * of size one, so get the first element out. Now modify the list to add
+             * our new values to the existing ones, and to increment the count.
+             */
+            data = data[0];
+            prev[data.idx] = {
+                date: curr.date,
+                Sensitive: data.Sensitive + curr.Sensitive,
+                'Somewhat Sensitive': data['Somewhat Sensitive'] + curr['Somewhat Sensitive'],
+                Tolerant: data.Tolerant + curr.Tolerant,
+                Total: data.Total + curr.Total,
+                count: data.count + 1,
+            }
         }
-      }
-      return prev;
+        return prev;
     }, []).map((value) => {
-      /*
-       * Now our list should look like this:
-       *
-       * [
-       *   {
-       *     date: '...',
-       *     Sensitive: ...,
-       *     'Somewhat Sensitive': ...,
-       *     Tolerant: ...,
-       *     Total: ...,
-       *     count: ...,
-       *     idx: 1,
-       *   },
-       *   {
-       *     ...
-       *   },
-       *   ...
-       * ]
-       *
-       * So, we mostly have the format we want. We just need to divide the sums
-       * by the count to get our averages, and filter the counts and indexes out
-       * of our data.
-       */
-      return {
-        date: value.date,
-        Sensitive: value.Sensitive / value.count,
-        'Somewhat Sensitive': value['Somewhat Sensitive'] / value.count,
-        Tolerant: value.Tolerant / value.count,
-        Total: value.Total / value.count,
-      };
+        /*
+         * Now our list should look like this:
+         *
+         * [
+         *   {
+         *     date: '...',
+         *     Sensitive: ...,
+         *     'Somewhat Sensitive': ...,
+         *     Tolerant: ...,
+         *     Total: ...,
+         *     count: ...,
+         *     idx: 1,
+         *   },
+         *   {
+         *     ...
+         *   },
+         *   ...
+         * ]
+         *
+         * So, we mostly have the format we want. We just need to divide the sums
+         * by the count to get our averages, and filter the counts and indexes out
+         * of our data.
+         */
+        return {
+            date: value.date,
+            Sensitive: value.Sensitive / value.count,
+            'Somewhat Sensitive': value['Somewhat Sensitive'] / value.count,
+            Tolerant: value.Tolerant / value.count,
+            Total: value.Total / value.count,
+        };
     });
 
     formatted.sort((a, b) => {
@@ -231,26 +236,38 @@ const useLineGraph = function useLineGraph() {
         .range([0, width]);
 
     x.domain([
-      date_range[0] !== 0 ? new Date(date_range[0]) :
-        d3.min(formatted, (d) => { return new Date(d.date) }),
-      date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-        d3.max(formatted, (d) => { return new Date(d.date) }),
+        date_range[0] !== 0 ? new Date(date_range[0]) :
+            d3.min(formatted, (d) => {
+                return new Date(d.date)
+            }),
+        date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
+            d3.max(formatted, (d) => {
+                return new Date(d.date)
+            }),
     ]);
     const y = d3.scaleLinear()
         .domain([0,
             d3.max(types, (c) => {
-                return d3.max(c.values, (d) => { return d.value })
+                return d3.max(c.values, (d) => {
+                    return d.value
+                })
             })
         ])
         .range([height, 0]);
     const z = d3.scaleOrdinal()
-        .domain(types.map((c) => { return c.name }))
+        .domain(types.map((c) => {
+            return c.name
+        }))
         .range(['#869099', '#8c7853', '#007d4a', '#e24431']);
 
     const line = d3.line()
         .curve(d3.curveLinear)
-        .x((d) => { return x(new Date(d.date)) })
-        .y((d) => { return y(d.value) });
+        .x((d) => {
+            return x(new Date(d.date))
+        })
+        .y((d) => {
+            return y(d.value)
+        });
 
     const svg = d3.select('#graph-' + siteId).append('svg')
         .attr('width', width + margin.left + margin.right)
@@ -269,53 +286,72 @@ const useLineGraph = function useLineGraph() {
         .call(d3.axisLeft(y));
 
     if (formatted.length > 0) {
-      const type = g.selectAll('.type')
-          .data(types)
-          .enter()
-      .append('g')
-          .attr('class', 'type');
+        const type = g.selectAll('.type')
+            .data(types)
+            .enter()
+            .append('g')
+            .attr('class', 'type');
 
-      type.append('path')
-          .attr('class', 'line')
-          .attr('d', (d) => { return line(d.values) })
-          .style('stroke', (d) => { return z(d.name) });
+        type.append('path')
+            .attr('class', 'line')
+            .attr('d', (d) => {
+                return line(d.values)
+            })
+            .style('stroke', (d) => {
+                return z(d.name)
+            });
 
-      type.selectAll('dot')
-          .data((d) => {
-            return d.values.map((e) => { e['name'] = d.name; return e});
-          })
-        .enter().append('circle')
-          .attr('r', 3.5)
-          .attr('cx', (d) => {
-            return x(new Date(d.date))
-          })
-          .attr('cy', (d) => { return y(d.value)})
-          .style('stroke', (d) => { return z(d.name) })
-          .style('fill', (d) => { return z(d.name) });
+        type.selectAll('dot')
+            .data((d) => {
+                return d.values.map((e) => {
+                    e['name'] = d.name;
+                    return e
+                });
+            })
+            .enter().append('circle')
+            .attr('r', 3.5)
+            .attr('cx', (d) => {
+                return x(new Date(d.date))
+            })
+            .attr('cy', (d) => {
+                return y(d.value)
+            })
+            .style('stroke', (d) => {
+                return z(d.name)
+            })
+            .style('fill', (d) => {
+                return z(d.name)
+            });
 
-      const legend = g.selectAll('.legend')
-          .data(types)
-          .enter()
-      .append('g')
-          .attr('class', 'legend')
-          .attr('transform', (d,i) => {
-            return 'translate(' + (width + margin.left + 5) + ', ' + i*20 + ')';
-          })
-          .style('border', '1px solid black')
-          .style('font', '12px sans-serif');
+        const legend = g.selectAll('.legend')
+            .data(types)
+            .enter()
+            .append('g')
+            .attr('class', 'legend')
+            .attr('transform', (d, i) => {
+                return 'translate(' + (width + margin.left + 5) + ', ' + i * 20 + ')';
+            })
+            .style('border', '1px solid black')
+            .style('font', '12px sans-serif');
 
-      legend.append('rect')
-          .attr('x', 2)
-          .attr('width', 18)
-          .attr('height', 2)
-          .attr('fill', (d) => { return z(d.name); });
+        legend.append('rect')
+            .attr('x', 2)
+            .attr('width', 18)
+            .attr('height', 2)
+            .attr('fill', (d) => {
+                return z(d.name);
+            });
 
-      legend.append('text')
-          .attr('x', 25)
-          .attr('dy', '.35em')
-          .attr('text-anchor', 'begin')
-          .attr('fill', (d) => { return z(d.name); })
-          .text((d) => { return d.name; });
+        legend.append('text')
+            .attr('x', 25)
+            .attr('dy', '.35em')
+            .attr('text-anchor', 'begin')
+            .attr('fill', (d) => {
+                return z(d.name);
+            })
+            .text((d) => {
+                return d.name;
+            });
     }
 };
 
@@ -328,7 +364,12 @@ const useBarGraph = function useBarGraph() {
     // Copy the data so we don't change the original
     data = JSON.parse(JSON.stringify(window.data_summ));
 
-    const categories = {'tolerant': [], 'somewhat': [], 'sensitive': [], 'total': []};
+    const categories = {
+        'tolerant': [],
+        'somewhat': [],
+        'sensitive': [],
+        'total': []
+    };
 
     let numEntries = 0;
     for (let key in data) {
@@ -385,19 +426,28 @@ const useBarGraph = function useBarGraph() {
             continue;
         }
 
-        const species = categories[category];
+        const species = categories[category].filter(d => {
+            return !isNaN(d.value);
+        }).sort((a, b) => {
+            return a.name.localeCompare(b.name);
+        });
 
         const container = $('#graph-' + siteId + '-' + category);
-        const margin = {top: 50, right: 200, bottom: 40, left: 50};
-        const width = (container.width() * 0.7) - margin.left - margin.right;
+        const margin = {top: 50, right: 100, bottom: 40, left: 50};
+        const width = (Math.min(container.width(), 150 * species.length)) -
+            margin.left - margin.right;
         const height = 256 - margin.top - margin.bottom;
 
         const x = d3.scaleBand()
-            .domain(species.map((d) => { return d.name }))
+            .domain(species.map((d) => {
+                return d.name
+            }))
             .range([0, width])
             .paddingInner(0.1);
         const y = d3.scaleLinear()
-            .domain([0, d3.max(species, (d) => { return d.value })])
+            .domain([0, d3.max(species, (d) => {
+                return d.value
+            }) || 1])
             .range([height, 0]);
 
         const xAxis = d3.axisBottom(x);
@@ -408,7 +458,7 @@ const useBarGraph = function useBarGraph() {
             .attr('height', height + margin.top + margin.bottom)
             .attr('xmlns', 'http://www.w3.org/2000/svg')
             .attr('xmlns:xlink', 'http://www.w3.org/1999/xlink')
-        .append('g')
+            .append('g')
             .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
         svg.append('g')
@@ -419,53 +469,65 @@ const useBarGraph = function useBarGraph() {
         svg.append('g')
             .attr('class', 'y axis')
             .call(yAxis)
-        .append('text')
+            .append('text')
             .attr('transform', 'rotate(-90)')
             .attr('y', 6)
             .attr('dy', '.71em')
             .style('text-anchor', 'end')
             .text('Frequency');
 
-        svg.selectAll('.bar')
-            .data(species)
-            .enter()
-        .append('rect')
-            .attr('class', 'bar')
-            .attr('x', (d) => { return x(d.name) })
-            .attr('width', x.bandwidth())
-            .attr('y', (d) => { return y(d.value) })
-            .attr('height', (d) => { return height - y(d.value) })
-            .attr('x-data-name', (d) => { return d.name })
-            .attr('x-data-value', (d) => { return d.value });
+        if (species.length > 0) {
+            svg.selectAll('.bar')
+                .data(species)
+                .enter()
+                .append('rect')
+                .attr('class', 'bar')
+                .attr('x', (d) => {
+                    return x(d.name)
+                })
+                .attr('width', x.bandwidth())
+                .attr('y', (d) => {
+                    return y(d.value || 0)
+                })
+                .attr('height', (d) => {
+                    return height - y(d.value || 0)
+                })
+                .attr('x-data-name', (d) => {
+                    return d.name
+                })
+                .attr('x-data-value', (d) => {
+                    return d.value || 0
+                });
 
-        const hover = svg.append('g')
-            .attr('class', 'bar-img')
-            .attr('transform', 'translate(0,0)')
-            .attr('width', 130)
-            .attr('height', 65)
-            .attr('opacity', 0);
+            const hover = svg.append('g')
+                .attr('class', 'bar-img')
+                .attr('transform', 'translate(0,0)')
+                .attr('width', 130)
+                .attr('height', 65)
+                .attr('opacity', 0);
 
-        hover.append('rect')
-            .attr('x', 0)
-            .attr('y', 0)
-            .attr('width', 130)
-            .attr('height', 65)
-            .attr('fill', '#ffffff')
-            .attr('stroke', '#000000')
-            .style('border', '1px solid black');
+            hover.append('rect')
+                .attr('x', 0)
+                .attr('y', 0)
+                .attr('width', 130)
+                .attr('height', 65)
+                .attr('fill', '#ffffff')
+                .attr('stroke', '#000000')
+                .style('border', '1px solid black');
 
-        hover.append('image')
-            .attr('x', 0)
-            .attr('y', 0)
-            .attr('width', 125)
-            .attr('height', 45)
-            .attr('xlink:href', '/static/streamwebs/images/macroinvertebrates/macro_snail.png');
+            hover.append('image')
+                .attr('x', 0)
+                .attr('y', 0)
+                .attr('width', 125)
+                .attr('height', 45)
+                .attr('xlink:href', '/static/streamwebs/images/macroinvertebrates/macro_snail.png');
 
-        hover.append('text')
-            .attr('x', 10)
-            .attr('y', 55)
-            .attr('dy', '0.2em')
-            .style('font', '10px sans-serif');
+            hover.append('text')
+                .attr('x', 10)
+                .attr('y', 55)
+                .attr('dy', '0.2em')
+                .style('font', '10px sans-serif');
+        }
     }
 
     const totals = categories['total'];
@@ -473,13 +535,20 @@ const useBarGraph = function useBarGraph() {
     for (let total of totals) {
         sum += total.value;
     }
-    const names = {'sensitive': 'Sensitive', 'somewhat': 'Somewhat Sensitive', 'tolerant': 'Tolerant'};
+    const names = {
+        'sensitive': 'Sensitive',
+        'somewhat': 'Somewhat Sensitive',
+        'tolerant': 'Tolerant'
+    };
     const columns = ['Sensitive', 'Somewhat Sensitive', 'Tolerant'];
 
     const container = $('#graph-' + siteId + '-pie');
-    const width = container.width() * 0.5;
-    const height = 256;
     const margin = {top: 30, right: 20, bottom: 30, left: 20};
+    const width = Math.min(
+        container.width() - margin.right - margin.left,
+        768
+    );
+    const height = 256;
     const radius = Math.min(width, height) / 2;
 
     const color = d3.scaleOrdinal()
@@ -492,45 +561,55 @@ const useBarGraph = function useBarGraph() {
 
     const pie = d3.pie()
         .sort(null)
-        .value((d) => { return d.value });
+        .value((d) => {
+            return d.value
+        });
 
     const svg = d3.select('#graph-' + siteId + '-pie').append('svg')
         .attr('width', width + margin.left + margin.right)
         .attr('height', height + margin.top + margin.bottom);
 
     const g = svg.append('g')
-        .attr('transform', 'translate(' + (width/2 + margin.left) + ',' + (height/2 + margin.top) + ')');
+        .attr('transform', 'translate(' + (width / 2 + margin.left) + ',' + (height / 2 + margin.top) + ')');
 
     const arcs = g.selectAll('.arc')
         .data(pie(totals))
         .enter()
-    .append('g')
+        .append('g')
         .attr('class', 'arc');
 
     arcs.append('path')
         .attr('d', arc)
-        .style('fill', (d) => { return color(d.data.name) });
+        .style('fill', (d) => {
+            return color(d.data.name)
+        });
 
     const legend = svg.selectAll('.legend')
         .data(totals)
         .enter()
-    .append('g')
+        .append('g')
         .attr('class', 'legend')
-        .attr('transform', (d,i) => { return 'translate(0, ' + i*20 + ')'; })
+        .attr('transform', (d, i) => {
+            return 'translate(0, ' + i * 20 + ')';
+        })
         .style('font', '12px sans-serif');
 
     legend.append('rect')
         .attr('x', width - 18)
         .attr('width', 18)
         .attr('height', 18)
-        .attr('fill', (d) => { return color(d.name); });
+        .attr('fill', (d) => {
+            return color(d.name);
+        });
 
     legend.append('text')
         .attr('x', width - 24)
         .attr('y', 9)
         .attr('dy', '.35em')
         .attr('text-anchor', 'end')
-        .text((d) => { return names[d.name] + ' (' + toFixed(((d.value/sum)*100), 2) + '%)'; });
+        .text((d) => {
+            return names[d.name] + ' (' + toFixed(((d.value / sum) * 100), 2) + '%)';
+        });
 
     $('.bar').mouseenter((e) => {
         const target = $(e.target);
@@ -543,16 +622,16 @@ const useBarGraph = function useBarGraph() {
         g.attr('transform',
             'translate(' +
             (parseFloat(target.attr('x')) + parseFloat(target.attr('width')) + 10) +
-            ',' + (parseFloat(target.attr('height')) + parseFloat(target.attr('y')))/4 + ')'
+            ',' + (parseFloat(target.attr('height')) + parseFloat(target.attr('y'))) / 4 + ')'
         );
         g.find('text').html(
             target.attr('x-data-name') + ' (' + toFixed(target.attr('x-data-value'), 2) + ')'
         );
         g.attr('opacity', 1);
     })
-    .mouseleave((e) => {
-        $(e.target).siblings('.bar-img').attr('opacity', 0);
-    });
+        .mouseleave((e) => {
+            $(e.target).siblings('.bar-img').attr('opacity', 0);
+        });
 };
 
 // Fix for broken .change() event on radio buttons
@@ -572,7 +651,7 @@ $.fn.fix_radios = function fix_radios() {
             return;
         }
 
-        $('input[name=' + this.name + ']').each(function() {
+        $('input[name=' + this.name + ']').each(function () {
             this.was_checked = this.checked;
         });
     }

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/water_quality.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/water_quality.js
@@ -270,21 +270,24 @@ const createGraph = function createGraph() {
                 }),
         ]);
         const water_min = d3.min(types.water_temperature, d => {
-            return d.value;
-        }) || 0;
+            // Sometimes we have NaN, null, or undefined, so remove those
+            // so that d3.min returns a numeric value
+            return d.value || 0;
+        }) || 0; // If d3.min is given an empty array, it returns Nan,
+                 // So substitute a reasonable default
         const air_min = d3.min(types.air_temperature, d => {
-            return d.value;
+            return d.value || 0;
         }) || 0;
         const water_max = d3.max(types.water_temperature, (d) => {
-            return d.value;
+            return d.value || 1;
         }) || 1;
         const air_max = d3.max(types.air_temperature, (d) => {
-            return d.value;
+            return d.value || 1;
         }) || 1;
         const y = d3.scaleLinear()
             .domain([
-                Math.floor(Math.min(0, water_min, air_min)),
-                Math.ceil(Math.max(1, water_max, air_max))
+                Math.floor(Math.min(0, water_min, air_min)) || 0,
+                Math.ceil(Math.max(1, water_max, air_max)) || 1
             ])
             .range([height, 0]);
         const z = d3.scaleOrdinal()
@@ -422,7 +425,7 @@ const createGraph = function createGraph() {
         ]);
         const y = d3.scaleLinear()
             .domain([0, Math.ceil(d3.max(types.dissolved_oxygen, (d) => {
-                return d.value;
+                return d.value || 1;
             }) || 1)
             ])
             .range([height, 0]);
@@ -599,10 +602,10 @@ const createGraph = function createGraph() {
         const y = d3.scaleLinear()
             .domain([
                 Math.floor(Math.min(0, d3.min(types.turbidity, (d) => {
-                    return d.value;
+                    return d.value || 0;
                 }) || 0)),
                 Math.ceil(d3.max(types.turbidity, (d) => {
-                    return d.value;
+                    return d.value || 1;
                 }) || 1)
             ])
             .range([height, 0]);
@@ -691,10 +694,10 @@ const createGraph = function createGraph() {
         const y = d3.scaleLinear()
             .domain([
                 Math.floor(Math.min(0, d3.min(types.salinity, (d) => {
-                    return d.value;
+                    return d.value || 0;
                 }) || 0)),
                 Math.ceil(d3.max(types.salinity, (d) => {
-                    return d.value;
+                    return d.value || 1;
                 }) || 1)
             ])
             .range([height, 0]);
@@ -783,7 +786,7 @@ const createGraph = function createGraph() {
         const y = d3.scaleLinear()
             .domain([0,
                 Math.ceil(d3.max(types.conductivity, (d) => {
-                    return d.value;
+                    return d.value || 1;
                 }) || 1)
             ])
             .range([height, 0]);
@@ -874,24 +877,24 @@ const createGraph = function createGraph() {
                 Math.floor(Math.min(
                     0,
                     d3.min(types.total_solids, (d) => {
-                        return d.value;
+                        return d.value || 0;
                     }) || 0,
                     d3.min(types.ammonia, (d) => {
-                        return d.value;
+                        return d.value || 0;
                     }) || 0,
                     d3.min(types.nitrate, (d) => {
-                        return d.value;
+                        return d.value || 0;
                     }) || 0,
                     d3.min(types.nitrite, (d) => {
-                        return d.value;
+                        return d.value || 0;
                     }) || 0,
                     d3.min(types.phosphates, (d) => {
-                        return d.value;
+                        return d.value || 0;
                     }) || 0
                 )),
                 Math.ceil(
                     d3.max(types.total_solids, (d) => {
-                        return d.value;
+                        return d.value || 1;
                     }) || 1
                 )
             ])
@@ -1033,7 +1036,7 @@ const createGraph = function createGraph() {
         const y = d3.scaleLinear()
             .domain([0,
                 Math.ceil(d3.max(types.bod, (d) => {
-                    return d.value;
+                    return d.value || 1;
                 }) || 1)
             ])
             .range([height, 0]);
@@ -1122,7 +1125,7 @@ const createGraph = function createGraph() {
         const y = d3.scaleLinear()
             .domain([0,
                 Math.ceil(d3.max(types.fecal_coliform, (d) => {
-                    return d.value;
+                    return d.value || 1;
                 }) || 1)
             ])
             .range([height, 0]);

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/water_quality.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/water_quality.js
@@ -56,157 +56,195 @@ const createGraph = function createGraph() {
     });
 
     const types = {
-      /*
-       * So we currently have a list of data points, each one containing a date
-       * and a list of 4 samples, each sample having one each of every data type
-       * we need. Instead, we want to pull out just one type per data point and
-       * pair it with the date.
-       *
-       * Get comfortable with this code, because we're about to repeat it for
-       * every data type.
-       */
-      water_temperature: formatted.map((d) => {
         /*
-         * Turn each data point *d*, which looks like this:
+         * So we currently have a list of data points, each one containing a date
+         * and a list of 4 samples, each sample having one each of every data type
+         * we need. Instead, we want to pull out just one type per data point and
+         * pair it with the date.
          *
-         * {
-         *  date: ...,
-         *  samples: [
-         *    {
-         *      water_temperature: ...,
-         *      ...
-         *    },
-         *    ...
-         *  ],
-         *  ...
-         * }
-         *
-         * into just a date-value pair.
+         * Get comfortable with this code, because we're about to repeat it for
+         * every data type.
          */
-        return {
-          date: d.date,
-          /*
-           * Take our samples, and reduce it into a single average for a value.
-           */
-          value: d.samples.reduce((prev, curr, idx) => {
+        water_temperature: formatted.map((d) => {
             /*
-             * This is more straightforward than it looks. Prev is the average
-             * of samples[0] through samples[idx-1]. We multiply it by the
-             * of points we've calculated so far (since idx is 0-indexed, it's
-             * just that), which is the total. Add the new value, then divide
-             * again.
+             * Turn each data point *d*, which looks like this:
              *
-             * Thus we can calculate an average on the fly without explicitly
-             * summing and dividing.
+             * {
+             *  date: ...,
+             *  samples: [
+             *    {
+             *      water_temperature: ...,
+             *      ...
+             *    },
+             *    ...
+             *  ],
+             *  ...
+             * }
+             *
+             * into just a date-value pair.
              */
-            return ((prev * idx) + parseFloat(curr.water_temperature))/(idx+1);
-          }, 0),
-        };
-      }),
-      air_temperature: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.air_temperature))/(idx+1);
-          }, 0),
-        };
-      }),
-      dissolved_oxygen: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.dissolved_oxygen))/(idx+1);
-          }, 0),
-        };
-      }),
-      pH: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.pH))/(idx+1);
-          }, 0),
-        };
-      }),
-      turbidity: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.turbidity))/(idx+1);
-          }, 0),
-        };
-      }),
-      salinity: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.salinity))/(idx+1);
-          }, 0),
-        };
-      }),
-      conductivity: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.conductivity))/(idx+1);
-          }, 0),
-        };
-      }),
-      fecal_coliform: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.fecal_coliform))/(idx+1);
-          }, 0),
-        };
-      }),
-      total_solids: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.total_solids))/(idx+1);
-          }, 0),
-        };
-      }),
-      bod: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.bod))/(idx+1);
-          }, 0),
-        };
-      }),
-      ammonia: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.ammonia))/(idx+1);
-          }, 0),
-        };
-      }),
-      nitrite: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.nitrite))/(idx+1);
-          }, 0),
-        };
-      }),
-      nitrate: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.nitrate))/(idx+1);
-          }, 0),
-        };
-      }),
-      phosphates: formatted.map((d) => {
-        return {
-          date: d.date,
-          value: d.samples.reduce((prev, curr, idx) => {
-            return ((prev * idx) + parseFloat(curr.phosphates))/(idx+1);
-          }, 0),
-        };
-      }),
+            return {
+                date: d.date,
+                /*
+                 * Take our samples, and reduce it into a single average for a value.
+                 */
+                value: d.samples.reduce((prev, curr, idx) => {
+                    /*
+                     * This is more straightforward than it looks. Prev is the average
+                     * of samples[0] through samples[idx-1]. We multiply it by the
+                     * of points we've calculated so far (since idx is 0-indexed, it's
+                     * just that), which is the total. Add the new value, then divide
+                     * again.
+                     *
+                     * Thus we can calculate an average on the fly without explicitly
+                     * summing and dividing.
+                     */
+                    return ((prev * idx) + parseFloat(curr.water_temperature)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        air_temperature: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.air_temperature)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        dissolved_oxygen: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.dissolved_oxygen)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        pH: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.pH)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        turbidity: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.turbidity)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        salinity: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.salinity)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        conductivity: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.conductivity)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        fecal_coliform: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.fecal_coliform)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        total_solids: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.total_solids)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        bod: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.bod)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        ammonia: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.ammonia)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        nitrite: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.nitrite)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        nitrate: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.nitrate)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+        phosphates: formatted.map((d) => {
+            return {
+                date: d.date,
+                value: d.samples.reduce((prev, curr, idx) => {
+                    return ((prev * idx) + parseFloat(curr.phosphates)) / (idx + 1);
+                }, 0),
+            };
+        }).filter(d => {
+            return !isNaN(d.value);
+        }),
+    };
+
+    const margin = {top: 20, right: 200, bottom: 30, left: 40};
+    const defineWidth = function definedefineWidth(container) {
+        return (Math.min(container.width(), 35 * formatted.length)) -
+            margin.left - margin.right;
+    };
+
+    const defineHeight = function definedefineHeight(container) {
+        return 200 - margin.top - margin.bottom;
     };
 
     /***************************************************************************
@@ -214,135 +252,150 @@ const createGraph = function createGraph() {
      **************************************************************************/
 
     {
-      const containerName = '#graph-' + siteId + '-temperature';
-      const container = outerContainer.find(containerName);
-      const margin = {top: 20, right: 200, bottom: 30, left: 40};
-      const width = (container.width() * 0.5) - margin.left - margin.right;
-      const height = 192 - margin.top - margin.bottom;
+        const containerName = '#graph-' + siteId + '-temperature';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-      const x = d3.scaleTime()
-          .range([0, width]);
-          x.domain([
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
             date_range[0] !== 0 ? new Date(date_range[0]) :
-              d3.min(formatted, (d) => { return new Date(d.date) }),
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-              d3.max(formatted, (d) => { return new Date(d.date) }),
-          ]);
-      const y = d3.scaleLinear()
-          .domain([
-              Math.floor(Math.min(
-                0,
-                d3.min(types.water_temperature, (d) => {
-                    return d.value;
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
                 }),
-                d3.min(types.air_temperature, (d) => {
-                    return d.value;
-                })
-              )),
-              Math.ceil(Math.max(
-                d3.max(types.water_temperature, (d) => {
-                    return d.value;
-                }),
-                d3.max(types.air_temperature, (d) => {
-                    return d.value;
-                })
-              ))
-          ])
-          .range([height, 0]);
-      const z = d3.scaleOrdinal()
-          .domain(['Air Temperature', 'Water Temperature'])
-          .range(['#6cbcfc', '#0310fc']);
-
-      const line = d3.line()
-          .curve(d3.curveLinear)
-          .x((d) => {
-            return x(d.date)
-          })
-          .y((d) => {
-            return y(d.value)
-          });
-
-      const svg = d3.select(containerName).append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom);
-
-      const g = svg.append('g')
-          .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-      g.append('g')
-          .attr('class', 'axis axis--x')
-          .attr('transform', 'translate(0, ' + height + ')')
-          .call(d3.axisBottom(x));
-
-      g.append('g')
-          .attr('class', 'axis axis--y')
-          .call(d3.axisLeft(y));
-
-      if (formatted.length > 0) {
-        const type = g.selectAll('.temp')
-            .data([
-              {name: "Water Temperature", values: types.water_temperature},
-              {name: "Air Temperature", values: types.air_temperature},
+        ]);
+        const water_min = d3.min(types.water_temperature, d => {
+            return d.value;
+        }) || 0;
+        const air_min = d3.min(types.air_temperature, d => {
+            return d.value;
+        }) || 0;
+        const water_max = d3.max(types.water_temperature, (d) => {
+            return d.value;
+        }) || 1;
+        const air_max = d3.max(types.air_temperature, (d) => {
+            return d.value;
+        }) || 1;
+        const y = d3.scaleLinear()
+            .domain([
+                Math.floor(Math.min(0, water_min, air_min)),
+                Math.ceil(Math.max(1, water_max, air_max))
             ])
-            .enter()
-        .append('g')
-            .attr('class', 'temp');
+            .range([height, 0]);
+        const z = d3.scaleOrdinal()
+            .domain(['Air Temperature', 'Water Temperature'])
+            .range(['#6cbcfc', '#0310fc']);
 
-        type.append('path')
-            .attr('class', 'line')
-            .attr('d', (d) => {
-              return line(d.values)
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
             })
-            .style('stroke', (d) => {
-              return z(d.name)
+            .y((d) => {
+                return y(d.value)
             });
 
-        type.selectAll('dot')
-            .data((d) => {
-              return d.values.map((e) => { e['name'] = d.name; return e});
-            })
-          .enter().append('circle')
-            .attr('r', 3.5)
-            .attr('cx', (d) => {
-              return x(new Date(d.date))
-            })
-            .attr('cy', (d) => { return y(d.value)})
-            .style('stroke', (d) => { return z(d.name) })
-            .style('fill', (d) => { return z(d.name) })
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
 
-        const legend = g.selectAll('.legend')
-            .data([
-              {name: "Water Temperature", values: types.water_temperature},
-              {name: "Air Temperature", values: types.air_temperature},
-            ])
-            .enter()
-        .append('g')
-            .attr('class', 'legend')
-            .attr('transform', (d,i) => {
-              return 'translate(' + (width + 10) + ', ' + i*20 + ')';
-            })
-            .style('border', '1px solid black')
-            .style('font', '12px sans-serif');
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-        legend.append('rect')
-            .attr('x', 2)
-            .attr('width', 18)
-            .attr('height', 2)
-            .attr('fill', (d) => {
-              return z(d.name);
-            });
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
 
-        legend.append('text')
-            .attr('x', 25)
-            .attr('dy', '.35em')
-            .attr('text-anchor', 'begin')
-            .attr('fill', (d) => {
-              return z(d.name);
-            })
-            .text((d) => {
-              return d.name;
-            });
-      }
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
+
+        if (types.water_temperature.length > 0 || types.air_temperature.length > 0) {
+            const type = g.selectAll('.temp')
+                .data([
+                    {
+                        name: "Water Temperature",
+                        values: types.water_temperature
+                    },
+                    {name: "Air Temperature", values: types.air_temperature},
+                ])
+                .enter()
+                .append('g')
+                .attr('class', 'temp');
+
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', (d) => {
+                    return z(d.name)
+                });
+
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', (d) => {
+                    return z(d.name)
+                })
+                .style('fill', (d) => {
+                    return z(d.name)
+                });
+
+            const legend = g.selectAll('.legend')
+                .data([
+                    {
+                        name: "Water Temperature",
+                        values: types.water_temperature
+                    },
+                    {name: "Air Temperature", values: types.air_temperature},
+                ])
+                .enter()
+                .append('g')
+                .attr('class', 'legend')
+                .attr('transform', (d, i) => {
+                    return 'translate(' + (width + 10) + ', ' + i * 20 + ')';
+                })
+                .style('border', '1px solid black')
+                .style('font', '12px sans-serif');
+
+            legend.append('rect')
+                .attr('x', 2)
+                .attr('width', 18)
+                .attr('height', 2)
+                .attr('fill', (d) => {
+                    return z(d.name);
+                });
+
+            legend.append('text')
+                .attr('x', 25)
+                .attr('dy', '.35em')
+                .attr('text-anchor', 'begin')
+                .attr('fill', (d) => {
+                    return z(d.name);
+                })
+                .text((d) => {
+                    return d.name;
+                });
+        }
     }
 
     /***************************************************************************
@@ -350,79 +403,90 @@ const createGraph = function createGraph() {
      **************************************************************************/
 
     {
-      const containerName = '#graph-' + siteId + '-oxygen';
-      const container = outerContainer.find(containerName);
-      const margin = {top: 20, right: 200, bottom: 30, left: 40};
-      const width = (container.width() * 0.5) - margin.left - margin.right;
-      const height = 192 - margin.top - margin.bottom;
+        const containerName = '#graph-' + siteId + '-oxygen';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-      const x = d3.scaleTime()
-          .range([0, width]);
-          x.domain([
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
             date_range[0] !== 0 ? new Date(date_range[0]) :
-              d3.min(formatted, (d) => { return new Date(d.date) }),
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-              d3.max(formatted, (d) => { return new Date(d.date) }),
-          ]);
-      const y = d3.scaleLinear()
-          .domain([0, Math.ceil(d3.max(types.dissolved_oxygen, (d) => {
-                  return d.value;
-              }))
-          ])
-          .range([height, 0]);
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([0, Math.ceil(d3.max(types.dissolved_oxygen, (d) => {
+                return d.value;
+            }) || 1)
+            ])
+            .range([height, 0]);
 
-      const line = d3.line()
-          .curve(d3.curveLinear)
-          .x((d) => {
-            return x(d.date)
-          })
-          .y((d) => {
-            return y(d.value)
-          });
-
-      const svg = d3.select(containerName).append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom);
-
-      const g = svg.append('g')
-          .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-      g.append('g')
-          .attr('class', 'axis axis--x')
-          .attr('transform', 'translate(0, ' + height + ')')
-          .call(d3.axisBottom(x));
-
-      g.append('g')
-          .attr('class', 'axis axis--y')
-          .call(d3.axisLeft(y));
-
-      if (formatted.length > 0) {
-        const type = g.selectAll('.do')
-            .data([{name: 'Dissolved Oxygen', values: types.dissolved_oxygen}])
-            .enter()
-        .append('g')
-            .attr('class', 'do');
-
-        type.append('path')
-            .attr('class', 'line')
-            .attr('d', (d) => {
-              return line(d.values)
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
             })
-            .style('stroke', '#93ece9');
+            .y((d) => {
+                return y(d.value)
+            });
 
-        type.selectAll('dot')
-            .data((d) => {
-              return d.values.map((e) => { e['name'] = d.name; return e});
-            })
-          .enter().append('circle')
-            .attr('r', 3.5)
-            .attr('cx', (d) => {
-              return x(new Date(d.date))
-            })
-            .attr('cy', (d) => { return y(d.value)})
-            .style('stroke', '#93ece9')
-            .style('fill', '#93ece9');
-      }
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
+
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
+
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
+
+        if (types.dissolved_oxygen.length > 0) {
+            const type = g.selectAll('.do')
+                .data([{
+                    name: 'Dissolved Oxygen',
+                    values: types.dissolved_oxygen
+                }])
+                .enter()
+                .append('g')
+                .attr('class', 'do');
+
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#93ece9');
+
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#93ece9')
+                .style('fill', '#93ece9');
+        }
     }
 
     /***************************************************************************
@@ -430,76 +494,84 @@ const createGraph = function createGraph() {
      **************************************************************************/
 
     {
-      const containerName = '#graph-' + siteId + '-ph';
-      const container = outerContainer.find(containerName);
-      const margin = {top: 20, right: 200, bottom: 30, left: 40};
-      const width = (container.width() * 0.5) - margin.left - margin.right;
-      const height = 192 - margin.top - margin.bottom;
+        const containerName = '#graph-' + siteId + '-ph';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-      const x = d3.scaleTime()
-          .range([0, width]);
-          x.domain([
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
             date_range[0] !== 0 ? new Date(date_range[0]) :
-              d3.min(formatted, (d) => { return new Date(d.date) }),
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-              d3.max(formatted, (d) => { return new Date(d.date) }),
-          ]);
-      const y = d3.scaleLinear()
-          .domain([0, 14])
-          .range([height, 0]);
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([0, 14])
+            .range([height, 0]);
 
-      const line = d3.line()
-          .curve(d3.curveLinear)
-          .x((d) => {
-            return x(d.date)
-          })
-          .y((d) => {
-            return y(d.value)
-          });
-
-      const svg = d3.select(containerName).append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom);
-
-      const g = svg.append('g')
-          .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-      g.append('g')
-          .attr('class', 'axis axis--x')
-          .attr('transform', 'translate(0, ' + height + ')')
-          .call(d3.axisBottom(x));
-
-      g.append('g')
-          .attr('class', 'axis axis--y')
-          .call(d3.axisLeft(y));
-
-      if (formatted.length > 0) {
-        const type = g.selectAll('.ph')
-            .data([{name: 'pH', values: types.pH}])
-            .enter()
-        .append('g')
-            .attr('class', 'ph');
-
-        type.append('path')
-            .attr('class', 'line')
-            .attr('d', (d) => {
-              return line(d.values)
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
             })
-            .style('stroke', '#aede5b');
+            .y((d) => {
+                return y(d.value)
+            });
 
-        type.selectAll('dot')
-            .data((d) => {
-              return d.values.map((e) => { e['name'] = d.name; return e});
-            })
-          .enter().append('circle')
-            .attr('r', 3.5)
-            .attr('cx', (d) => {
-              return x(new Date(d.date))
-            })
-            .attr('cy', (d) => { return y(d.value)})
-            .style('stroke', '#aede5b')
-            .style('fill', '#aede5b');
-      }
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
+
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
+
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
+
+        if (types.pH.length > 0) {
+            const type = g.selectAll('.ph')
+                .data([{name: 'pH', values: types.pH}])
+                .enter()
+                .append('g')
+                .attr('class', 'ph');
+
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#aede5b');
+
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#aede5b')
+                .style('fill', '#aede5b');
+        }
     }
 
     /***************************************************************************
@@ -507,83 +579,91 @@ const createGraph = function createGraph() {
      **************************************************************************/
 
     {
-      const containerName = '#graph-' + siteId + '-turbidity';
-      const container = outerContainer.find(containerName);
-      const margin = {top: 20, right: 200, bottom: 30, left: 40};
-      const width = (container.width() * 0.5) - margin.left - margin.right;
-      const height = 192 - margin.top - margin.bottom;
+        const containerName = '#graph-' + siteId + '-turbidity';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-      const x = d3.scaleTime()
-          .range([0, width]);
-          x.domain([
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
             date_range[0] !== 0 ? new Date(date_range[0]) :
-              d3.min(formatted, (d) => { return new Date(d.date) }),
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-              d3.max(formatted, (d) => { return new Date(d.date) }),
-          ]);
-      const y = d3.scaleLinear()
-          .domain([
-              Math.floor(Math.min(0, d3.min(types.turbidity, (d) => {
-                  return d.value;
-              }))),
-              Math.ceil(d3.max(types.turbidity, (d) => {
-                  return d.value;
-              }))
-          ])
-          .range([height, 0]);
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([
+                Math.floor(Math.min(0, d3.min(types.turbidity, (d) => {
+                    return d.value;
+                }) || 0)),
+                Math.ceil(d3.max(types.turbidity, (d) => {
+                    return d.value;
+                }) || 1)
+            ])
+            .range([height, 0]);
 
-      const line = d3.line()
-          .curve(d3.curveLinear)
-          .x((d) => {
-            return x(d.date)
-          })
-          .y((d) => {
-            return y(d.value)
-          });
-
-      const svg = d3.select(containerName).append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom);
-
-      const g = svg.append('g')
-          .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-      g.append('g')
-          .attr('class', 'axis axis--x')
-          .attr('transform', 'translate(0, ' + height + ')')
-          .call(d3.axisBottom(x));
-
-      g.append('g')
-          .attr('class', 'axis axis--y')
-          .call(d3.axisLeft(y));
-
-      if (formatted.length > 0) {
-        const type = g.selectAll('.turb')
-            .data([{name: 'Turbidity', values: types.turbidity}])
-            .enter()
-        .append('g')
-            .attr('class', 'turb');
-
-        type.append('path')
-            .attr('class', 'line')
-            .attr('d', (d) => {
-              return line(d.values)
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
             })
-            .style('stroke', '#636363');
+            .y((d) => {
+                return y(d.value)
+            });
 
-        type.selectAll('dot')
-            .data((d) => {
-              return d.values.map((e) => { e['name'] = d.name; return e});
-            })
-          .enter().append('circle')
-            .attr('r', 3.5)
-            .attr('cx', (d) => {
-              return x(new Date(d.date))
-            })
-            .attr('cy', (d) => { return y(d.value)})
-            .style('stroke', '#636363')
-            .style('fill', '#636363');
-      }
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
+
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
+
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
+
+        if (types.turbidity.length > 0) {
+            const type = g.selectAll('.turb')
+                .data([{name: 'Turbidity', values: types.turbidity}])
+                .enter()
+                .append('g')
+                .attr('class', 'turb');
+
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#636363');
+
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#636363')
+                .style('fill', '#636363');
+        }
     }
 
     /***************************************************************************
@@ -591,83 +671,91 @@ const createGraph = function createGraph() {
      **************************************************************************/
 
     {
-      const containerName = '#graph-' + siteId + '-salinity';
-      const container = outerContainer.find(containerName);
-      const margin = {top: 20, right: 200, bottom: 30, left: 40};
-      const width = (container.width() * 0.5) - margin.left - margin.right;
-      const height = 192 - margin.top - margin.bottom;
+        const containerName = '#graph-' + siteId + '-salinity';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-      const x = d3.scaleTime()
-          .range([0, width]);
-          x.domain([
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
             date_range[0] !== 0 ? new Date(date_range[0]) :
-              d3.min(formatted, (d) => { return new Date(d.date) }),
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-              d3.max(formatted, (d) => { return new Date(d.date) }),
-          ]);
-      const y = d3.scaleLinear()
-          .domain([
-              Math.floor(Math.min(0, d3.min(types.salinity, (d) => {
-                  return d.value;
-              }))),
-              Math.ceil(d3.max(types.salinity, (d) => {
-                  return d.value;
-              }))
-          ])
-          .range([height, 0]);
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([
+                Math.floor(Math.min(0, d3.min(types.salinity, (d) => {
+                    return d.value;
+                }) || 0)),
+                Math.ceil(d3.max(types.salinity, (d) => {
+                    return d.value;
+                }) || 1)
+            ])
+            .range([height, 0]);
 
-      const line = d3.line()
-          .curve(d3.curveLinear)
-          .x((d) => {
-            return x(d.date)
-          })
-          .y((d) => {
-            return y(d.value)
-          });
-
-      const svg = d3.select(containerName).append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom);
-
-      const g = svg.append('g')
-          .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-      g.append('g')
-          .attr('class', 'axis axis--x')
-          .attr('transform', 'translate(0, ' + height + ')')
-          .call(d3.axisBottom(x));
-
-      g.append('g')
-          .attr('class', 'axis axis--y')
-          .call(d3.axisLeft(y));
-
-      if (formatted.length > 0) {
-        const type = g.selectAll('.sal')
-            .data([{name: 'Salinity', values: types.salinity}])
-            .enter()
-        .append('g')
-            .attr('class', 'sal');
-
-        type.append('path')
-            .attr('class', 'line')
-            .attr('d', (d) => {
-              return line(d.values)
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
             })
-            .style('stroke', '#cccccc');
+            .y((d) => {
+                return y(d.value)
+            });
 
-        type.selectAll('dot')
-            .data((d) => {
-              return d.values.map((e) => { e['name'] = d.name; return e});
-            })
-          .enter().append('circle')
-            .attr('r', 3.5)
-            .attr('cx', (d) => {
-              return x(new Date(d.date))
-            })
-            .attr('cy', (d) => { return y(d.value)})
-            .style('stroke', '#cccccc')
-            .style('fill', '#cccccc');
-      }
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
+
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
+
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
+
+        if (types.salinity.length > 0) {
+            const type = g.selectAll('.sal')
+                .data([{name: 'Salinity', values: types.salinity}])
+                .enter()
+                .append('g')
+                .attr('class', 'sal');
+
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#cccccc');
+
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#cccccc')
+                .style('fill', '#cccccc');
+        }
     }
 
     /***************************************************************************
@@ -675,392 +763,428 @@ const createGraph = function createGraph() {
      **************************************************************************/
 
     {
-      const containerName = '#graph-' + siteId + '-conductivity';
-      const container = outerContainer.find(containerName);
-      const margin = {top: 20, right: 200, bottom: 30, left: 40};
-      const width = (container.width() * 0.5) - margin.left - margin.right;
-      const height = 192 - margin.top - margin.bottom;
+        const containerName = '#graph-' + siteId + '-conductivity';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-      const x = d3.scaleTime()
-          .range([0, width]);
-          x.domain([
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
             date_range[0] !== 0 ? new Date(date_range[0]) :
-              d3.min(formatted, (d) => { return new Date(d.date) }),
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-              d3.max(formatted, (d) => { return new Date(d.date) }),
-          ]);
-      const y = d3.scaleLinear()
-          .domain([0,
-              Math.ceil(d3.max(types.conductivity, (d) => {
-                  return d.value;
-              }))
-          ])
-          .range([height, 0]);
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([0,
+                Math.ceil(d3.max(types.conductivity, (d) => {
+                    return d.value;
+                }) || 1)
+            ])
+            .range([height, 0]);
 
-      const line = d3.line()
-          .curve(d3.curveLinear)
-          .x((d) => {
-            return x(d.date)
-          })
-          .y((d) => {
-            return y(d.value)
-          });
-
-      const svg = d3.select(containerName).append('svg')
-          .attr('width', width + margin.left + margin.right)
-          .attr('height', height + margin.top + margin.bottom);
-
-      const g = svg.append('g')
-          .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-      g.append('g')
-          .attr('class', 'axis axis--x')
-          .attr('transform', 'translate(0, ' + height + ')')
-          .call(d3.axisBottom(x));
-
-      g.append('g')
-          .attr('class', 'axis axis--y')
-          .call(d3.axisLeft(y));
-
-      if (formatted.length > 0) {
-        const type = g.selectAll('.cond')
-            .data([{name: 'Conductivity', values: types.conductivity}])
-            .enter()
-        .append('g')
-            .attr('class', 'cond');
-
-        type.append('path')
-            .attr('class', 'line')
-            .attr('d', (d) => {
-              return line(d.values)
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
             })
-            .style('stroke', '#f7f73e');
+            .y((d) => {
+                return y(d.value)
+            });
 
-        type.selectAll('dot')
-            .data((d) => {
-              return d.values.map((e) => { e['name'] = d.name; return e});
-            })
-          .enter().append('circle')
-            .attr('r', 3.5)
-            .attr('cx', (d) => {
-              return x(new Date(d.date))
-            })
-            .attr('cy', (d) => { return y(d.value)})
-            .style('stroke', '#f7f73e')
-            .style('fill', '#f7f73e');
-      }
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
+
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
+
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
+
+        if (types.conductivity.length > 0) {
+            const type = g.selectAll('.cond')
+                .data([{name: 'Conductivity', values: types.conductivity}])
+                .enter()
+                .append('g')
+                .attr('class', 'cond');
+
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#f7f73e');
+
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#f7f73e')
+                .style('fill', '#f7f73e');
+        }
     }
 
     /***************************************************************************
      * Dissolved Solids
      **************************************************************************/
 
-     {
-       const containerName = '#graph-' + siteId + '-dissolved';
-       const container = outerContainer.find(containerName);
-       const margin = {top: 20, right: 200, bottom: 30, left: 40};
-       const width = (container.width() * 0.5) - margin.left - margin.right;
-       const height = 192 - margin.top - margin.bottom;
+    {
+        const containerName = '#graph-' + siteId + '-dissolved';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-       const x = d3.scaleTime()
-           .range([0, width]);
-           x.domain([
-             date_range[0] !== 0 ? new Date(date_range[0]) :
-               d3.min(formatted, (d) => { return new Date(d.date) }),
-             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-               d3.max(formatted, (d) => { return new Date(d.date) }),
-           ]);
-       const y = d3.scaleLinear()
-           .domain([
-               Math.floor(Math.min(
-                 0,
-                 d3.min(types.total_solids, (d) => {
-                     return d.value;
-                 }),
-                 d3.min(types.ammonia, (d) => {
-                     return d.value;
-                 }),
-                 d3.min(types.nitrate, (d) => {
-                     return d.value;
-                 }),
-                 d3.min(types.nitrite, (d) => {
-                     return d.value;
-                 }),
-                 d3.min(types.phosphates, (d) => {
-                     return d.value;
-                 })
-               )),
-               Math.ceil(
-                 d3.max(types.total_solids, (d) => {
-                     return d.value;
-                 })
-               )
-           ])
-           .range([height, 0]);
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
+            date_range[0] !== 0 ? new Date(date_range[0]) :
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+            date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([
+                Math.floor(Math.min(
+                    0,
+                    d3.min(types.total_solids, (d) => {
+                        return d.value;
+                    }) || 0,
+                    d3.min(types.ammonia, (d) => {
+                        return d.value;
+                    }) || 0,
+                    d3.min(types.nitrate, (d) => {
+                        return d.value;
+                    }) || 0,
+                    d3.min(types.nitrite, (d) => {
+                        return d.value;
+                    }) || 0,
+                    d3.min(types.phosphates, (d) => {
+                        return d.value;
+                    }) || 0
+                )),
+                Math.ceil(
+                    d3.max(types.total_solids, (d) => {
+                        return d.value;
+                    }) || 1
+                )
+            ])
+            .range([height, 0]);
 
-       const z = d3.scaleOrdinal()
-           .domain(['Total Solids', 'Ammonia', 'Nitrite', 'Nitrate', 'Phosphates'])
-           .range(['#ababab', '#bfbf30', '#a8bf13', '#c8e60b', '#c9833c']);
+        const z = d3.scaleOrdinal()
+            .domain(['Total Solids', 'Ammonia', 'Nitrite', 'Nitrate', 'Phosphates'])
+            .range(['#ababab', '#bfbf30', '#a8bf13', '#c8e60b', '#c9833c']);
 
-       const line = d3.line()
-           .curve(d3.curveLinear)
-           .x((d) => {
-             return x(d.date)
-           })
-           .y((d) => {
-             return y(d.value)
-           });
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
+            })
+            .y((d) => {
+                return y(d.value)
+            });
 
-       const svg = d3.select(containerName).append('svg')
-           .attr('width', width + margin.left + margin.right)
-           .attr('height', height + margin.top + margin.bottom);
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
 
-       const g = svg.append('g')
-           .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-       g.append('g')
-           .attr('class', 'axis axis--x')
-           .attr('transform', 'translate(0, ' + height + ')')
-           .call(d3.axisBottom(x));
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
 
-       g.append('g')
-           .attr('class', 'axis axis--y')
-           .call(d3.axisLeft(y));
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
 
-       if (formatted.length > 0) {
-         const type = g.selectAll('.solids')
-             .data([
-               {name: "Total Solids", values: types.total_solids},
-               {name: "Ammonia", values: types.ammonia},
-               {name: "Nitrite", values: types.nitrite},
-               {name: "Nitrate", values: types.nitrate},
-               {name: "Phosphates", values: types.phosphates},
-             ])
-             .enter()
-         .append('g')
-             .attr('class', 'solids');
+        if (types.total_solids.length > 0) {
+            const type = g.selectAll('.solids')
+                .data([
+                    {name: "Total Solids", values: types.total_solids},
+                    {name: "Ammonia", values: types.ammonia},
+                    {name: "Nitrite", values: types.nitrite},
+                    {name: "Nitrate", values: types.nitrate},
+                    {name: "Phosphates", values: types.phosphates},
+                ])
+                .enter()
+                .append('g')
+                .attr('class', 'solids');
 
-         type.append('path')
-             .attr('class', 'line')
-             .attr('d', (d) => {
-               return line(d.values)
-             })
-             .style('stroke', (d) => {
-               return z(d.name)
-             });
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', (d) => {
+                    return z(d.name)
+                });
 
-         type.selectAll('dot')
-             .data((d) => {
-               return d.values.map((e) => { e['name'] = d.name; return e});
-             })
-           .enter().append('circle')
-             .attr('r', 3.5)
-             .attr('cx', (d) => {
-               return x(new Date(d.date))
-             })
-             .attr('cy', (d) => { return y(d.value)})
-             .style('stroke', (d) => { return z(d.name) })
-             .style('fill', (d) => { return z(d.name) })
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', (d) => {
+                    return z(d.name)
+                })
+                .style('fill', (d) => {
+                    return z(d.name)
+                });
 
-         const legend = g.selectAll('.legend')
-             .data([
-               {name: "Total Solids", values: types.total_solids},
-               {name: "Ammonia", values: types.ammonia},
-               {name: "Nitrite", values: types.nitrite},
-               {name: "Nitrate", values: types.nitrate},
-               {name: "Phosphates", values: types.phosphates},
-             ])
-             .enter()
-         .append('g')
-             .attr('class', 'legend')
-             .attr('transform', (d,i) => {
-               return 'translate(' + (width + 10) + ', ' + i*20 + ')';
-             })
-             .style('border', '1px solid black')
-             .style('font', '12px sans-serif');
+            const legend = g.selectAll('.legend')
+                .data([
+                    {name: "Total Solids", values: types.total_solids},
+                    {name: "Ammonia", values: types.ammonia},
+                    {name: "Nitrite", values: types.nitrite},
+                    {name: "Nitrate", values: types.nitrate},
+                    {name: "Phosphates", values: types.phosphates},
+                ])
+                .enter()
+                .append('g')
+                .attr('class', 'legend')
+                .attr('transform', (d, i) => {
+                    return 'translate(' + (width + 10) + ', ' + i * 20 + ')';
+                })
+                .style('border', '1px solid black')
+                .style('font', '12px sans-serif');
 
-         legend.append('rect')
-             .attr('x', 2)
-             .attr('width', 18)
-             .attr('height', 2)
-             .attr('fill', (d) => {
-               return z(d.name);
-             });
+            legend.append('rect')
+                .attr('x', 2)
+                .attr('width', 18)
+                .attr('height', 2)
+                .attr('fill', (d) => {
+                    return z(d.name);
+                });
 
-         legend.append('text')
-             .attr('x', 25)
-             .attr('dy', '.35em')
-             .attr('text-anchor', 'begin')
-             .attr('fill', (d) => {
-               return z(d.name);
-             })
-             .text((d) => {
-               return d.name;
-             });
-       }
-     }
+            legend.append('text')
+                .attr('x', 25)
+                .attr('dy', '.35em')
+                .attr('text-anchor', 'begin')
+                .attr('fill', (d) => {
+                    return z(d.name);
+                })
+                .text((d) => {
+                    return d.name;
+                });
+        }
+    }
 
-     /***************************************************************************
-      * BOD
-      **************************************************************************/
+    /***************************************************************************
+     * BOD
+     **************************************************************************/
 
-     {
-       const containerName = '#graph-' + siteId + '-bod';
-       const container = outerContainer.find(containerName);
-       const margin = {top: 20, right: 200, bottom: 30, left: 40};
-       const width = (container.width() * 0.5) - margin.left - margin.right;
-       const height = 192 - margin.top - margin.bottom;
+    {
+        const containerName = '#graph-' + siteId + '-bod';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-       const x = d3.scaleTime()
-           .range([0, width]);
-           x.domain([
-             date_range[0] !== 0 ? new Date(date_range[0]) :
-               d3.min(formatted, (d) => { return new Date(d.date) }),
-             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-               d3.max(formatted, (d) => { return new Date(d.date) }),
-           ]);
-       const y = d3.scaleLinear()
-           .domain([0,
-               Math.ceil(d3.max(types.bod, (d) => {
-                   return d.value;
-               }))
-           ])
-           .range([height, 0]);
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
+            date_range[0] !== 0 ? new Date(date_range[0]) :
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+            date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([0,
+                Math.ceil(d3.max(types.bod, (d) => {
+                    return d.value;
+                }) || 1)
+            ])
+            .range([height, 0]);
 
-       const line = d3.line()
-           .curve(d3.curveLinear)
-           .x((d) => {
-             return x(d.date)
-           })
-           .y((d) => {
-             return y(d.value)
-           });
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
+            })
+            .y((d) => {
+                return y(d.value)
+            });
 
-       const svg = d3.select(containerName).append('svg')
-           .attr('width', width + margin.left + margin.right)
-           .attr('height', height + margin.top + margin.bottom);
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
 
-       const g = svg.append('g')
-           .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-       g.append('g')
-           .attr('class', 'axis axis--x')
-           .attr('transform', 'translate(0, ' + height + ')')
-           .call(d3.axisBottom(x));
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
 
-       g.append('g')
-           .attr('class', 'axis axis--y')
-           .call(d3.axisLeft(y));
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
 
-       if (formatted.length > 0) {
-         const type = g.selectAll('.bod')
-             .data([{name: 'BOD', values: types.bod}])
-             .enter()
-         .append('g')
-             .attr('class', 'bod');
+        if (types.bod.length > 0) {
+            const type = g.selectAll('.bod')
+                .data([{name: 'BOD', values: types.bod}])
+                .enter()
+                .append('g')
+                .attr('class', 'bod');
 
-         type.append('path')
-             .attr('class', 'line')
-             .attr('d', (d) => {
-               return line(d.values)
-             })
-             .style('stroke', '#6851ed');
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#6851ed');
 
-         type.selectAll('dot')
-             .data((d) => {
-               return d.values.map((e) => { e['name'] = d.name; return e});
-             })
-           .enter().append('circle')
-             .attr('r', 3.5)
-             .attr('cx', (d) => {
-               return x(new Date(d.date))
-             })
-             .attr('cy', (d) => { return y(d.value)})
-             .style('stroke', '#6851ed')
-             .style('fill', '#6851ed');
-       }
-     }
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#6851ed')
+                .style('fill', '#6851ed');
+        }
+    }
 
-     /***************************************************************************
-      * Fecal Coliform
-      **************************************************************************/
+    /***************************************************************************
+     * Fecal Coliform
+     **************************************************************************/
 
-     {
-       const containerName = '#graph-' + siteId + '-coliform';
-       const container = outerContainer.find(containerName);
-       const margin = {top: 20, right: 200, bottom: 30, left: 40};
-       const width = (container.width() * 0.5) - margin.left - margin.right;
-       const height = 192 - margin.top - margin.bottom;
+    {
+        const containerName = '#graph-' + siteId + '-coliform';
+        const container = outerContainer.find(containerName);
+        const width = defineWidth(container);
+        const height = defineHeight(container);
 
-       const x = d3.scaleTime()
-           .range([0, width]);
-           x.domain([
-             date_range[0] !== 0 ? new Date(date_range[0]) :
-               d3.min(formatted, (d) => { return new Date(d.date) }),
-             date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
-               d3.max(formatted, (d) => { return new Date(d.date) }),
-           ]);
-       const y = d3.scaleLinear()
-           .domain([0,
-               Math.ceil(d3.max(types.fecal_coliform, (d) => {
-                   return d.value;
-               }))
-           ])
-           .range([height, 0]);
+        const x = d3.scaleTime()
+            .range([0, width]);
+        x.domain([
+            date_range[0] !== 0 ? new Date(date_range[0]) :
+                d3.min(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+            date_range[1] !== Number.MAX_SAFE_INTEGER ? new Date(date_range[1]) :
+                d3.max(formatted, (d) => {
+                    return new Date(d.date)
+                }),
+        ]);
+        const y = d3.scaleLinear()
+            .domain([0,
+                Math.ceil(d3.max(types.fecal_coliform, (d) => {
+                    return d.value;
+                }) || 1)
+            ])
+            .range([height, 0]);
 
-       const line = d3.line()
-           .curve(d3.curveLinear)
-           .x((d) => {
-             return x(d.date)
-           })
-           .y((d) => {
-             return y(d.value)
-           });
+        const line = d3.line()
+            .curve(d3.curveLinear)
+            .x((d) => {
+                return x(d.date)
+            })
+            .y((d) => {
+                return y(d.value)
+            });
 
-       const svg = d3.select(containerName).append('svg')
-           .attr('width', width + margin.left + margin.right)
-           .attr('height', height + margin.top + margin.bottom);
+        const svg = d3.select(containerName).append('svg')
+            .attr('width', width + margin.left + margin.right)
+            .attr('height', height + margin.top + margin.bottom);
 
-       const g = svg.append('g')
-           .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+        const g = svg.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-       g.append('g')
-           .attr('class', 'axis axis--x')
-           .attr('transform', 'translate(0, ' + height + ')')
-           .call(d3.axisBottom(x));
+        g.append('g')
+            .attr('class', 'axis axis--x')
+            .attr('transform', 'translate(0, ' + height + ')')
+            .call(d3.axisBottom(x));
 
-       g.append('g')
-           .attr('class', 'axis axis--y')
-           .call(d3.axisLeft(y));
+        g.append('g')
+            .attr('class', 'axis axis--y')
+            .call(d3.axisLeft(y));
 
-       if (formatted.length > 0) {
-         const type = g.selectAll('.fecal')
-             .data([{name: 'Fecal Coliform', values: types.fecal_coliform}])
-             .enter()
-         .append('g')
-             .attr('class', 'fecal');
+        if (types.fecal_coliform.length > 0) {
+            const type = g.selectAll('.fecal')
+                .data([{name: 'Fecal Coliform', values: types.fecal_coliform}])
+                .enter()
+                .append('g')
+                .attr('class', 'fecal');
 
-         type.append('path')
-             .attr('class', 'line')
-             .attr('d', (d) => {
-               return line(d.values)
-             })
-             .style('stroke', '#593e29');
+            type.append('path')
+                .attr('class', 'line')
+                .attr('d', (d) => {
+                    return line(d.values)
+                })
+                .style('stroke', '#593e29');
 
-         type.selectAll('dot')
-             .data((d) => {
-               return d.values.map((e) => { e['name'] = d.name; return e});
-             })
-           .enter().append('circle')
-             .attr('r', 3.5)
-             .attr('cx', (d) => {
-               return x(new Date(d.date))
-             })
-             .attr('cy', (d) => { return y(d.value)})
-             .style('stroke', '#593e29')
-             .style('fill', '#593e29');
-       }
-     }
+            type.selectAll('dot')
+                .data((d) => {
+                    return d.values.map((e) => {
+                        e['name'] = d.name;
+                        return e
+                    });
+                })
+                .enter().append('circle')
+                .attr('r', 3.5)
+                .attr('cx', (d) => {
+                    return x(new Date(d.date))
+                })
+                .attr('cy', (d) => {
+                    return y(d.value)
+                })
+                .style('stroke', '#593e29')
+                .style('fill', '#593e29');
+        }
+    }
 };
 
 $(() => {

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/water_quality.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/water_quality.js
@@ -237,9 +237,10 @@ const createGraph = function createGraph() {
         }),
     };
 
-    const margin = {top: 20, right: 200, bottom: 30, left: 40};
+    const margin = {top: 20, right: 100, bottom: 30, left: 40};
     const defineWidth = function definedefineWidth(container) {
-        return (Math.min(container.width(), 35 * formatted.length)) -
+        return (Math.max(container.width() / 2,
+                Math.min(container.width(), 35 * formatted.length))) -
             margin.left - margin.right;
     };
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #222.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Fix graph widths for water quality to prevent overlapping labels
- [X] Remove NaN values from water quality graph data to prevent SVG glitches
- [X] Set default ranges for water quality graphs so that axes are still present even with bad or no data
- [X] Don't display water quality graph data if none is present
- [X] Fix graph widths for macroinvertebrates to prevent overlapping labels
- [X] Sort bar graphs alphabetically by species name
- [X] Remove NaN values from macros graph data and force reasonable default values to prevent SVG glitches
- [X] Fix inconsistent code indentation across both files

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. `docker-compose up`
2. Look at the water quality graphs for the Amazon Creek site
3. Look at the macroinvertebrate graphs for the Shafer Creek site

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

* All graphs for Amazon Creek should have full axes and labels that don't overlap, regardless of time scale or whether the graph has data
* All graphs for Shafer Creek should have sufficient spacing between labels regardless of time scale

@osuosl/devs

**Hint**: If you add ``?w=1`` to the URL when viewing the diff of this PR, it ignores the whitespace changes and gives you a more readable diff.