### PR TITLE
Remove auth checks from templates.

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
@@ -6,25 +6,19 @@
 {% block body_title %}{% trans "Add a new camera point" %}{% endblock %}
 {% block content %}
 
-    {% if user.is_authenticated %}
-        {% if added %}
-        <strong>{% trans "You have successfully added a new camera point." %}</strong>
-        {% else %}
-        <form id='pp_monitoring_form' method='post' enctype='multipart/form-data'>
-            {% csrf_token %}
-            {{ camera_form.media }}
-            {{ camera_form.as_p }}
-            {{ pp_formset.as_p }}
-            {{ ppi_formset.as_p }}
+{% if added %}
+<strong>{% trans "You have successfully added a new camera point." %}</strong>
+{% else %}
+<form id='pp_monitoring_form' method='post' enctype='multipart/form-data'>
+    {% csrf_token %}
+    {{ camera_form.media }}
+    {{ camera_form.as_p }}
+    {{ pp_formset.as_p }}
+    {{ ppi_formset.as_p }}
 
-            <input type='submit' name='submit' value='Submit' class="btn waves-effect waves-light teal darken-4" />
-        </form>
-        {% endif %}
-
-    {% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-    <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
-    {% endif %}
+    <input type='submit' name='submit' value='Submit' class="btn waves-effect waves-light teal darken-4" />
+</form>
+{% endif %}
 
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -64,259 +64,254 @@
     }
 </style>
 
-{% if user.is_authenticated %}
-    {% if added %}
-        <strong>{% trans "You have successfully submitted your Canopy Cover Survey." %}</strong>
-
-    {% else %}
-    <h3 align="center">
-        <a href="{% url 'streamwebs:site' site.site_slug %}">
-            {{ site.site_name }}
-        </a>
-    </h3>
-    <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
-    <form id='canopy_cover_form' method='post'>
-    {% csrf_token %}
-        <table> <!-- main cc info table -->
-            <tr>{{ canopy_cover_form.non_field_errors }}</tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.school.label }}</th>
-                <td>{{ canopy_cover_form.school }}</td>
-                <td>{{ canopy_cover_form.school.errors }}</td>
-            </tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.date_time.label }}</th>
-                <td>{{ canopy_cover_form.date_time }}</td>
-                <td>{{ canopy_cover_form.date_time.errors }}</td>
-            </tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.weather.label }}</th>
-                <td>{{ canopy_cover_form.weather }}</td>
-                <td>{{ canopy_cover_form.weather.errors }}</td>
-            </tr>
-            <tr style='display: none'>
-                <th align='left'>{{ canopy_cover_form.north_cc.label }}</th>
-                <td id='north-form'>{{ canopy_cover_form.north_cc }}</td>
-                <td>{{ canopy_cover_form.north_cc.errors }}</td>
-            </tr>
-            <tr style='display: none'>
-                <th align='left'>{{ canopy_cover_form.east_cc.label }}</th>
-                <td id='east-form'>{{ canopy_cover_form.east_cc }}</td>
-                <td>{{ canopy_cover_form.east_cc.errors }}</td>
-            </tr>
-            <tr style='display: none'>
-                <th align='left'>{{ canopy_cover_form.west_cc.label }}</th>
-                <td id='west-form'>{{ canopy_cover_form.west_cc }}</td>
-                <td>{{ canopy_cover_form.west_cc.errors }}</td>
-            </tr>
-            <tr style='display: none'>
-                <th align='left'>{{ canopy_cover_form.south_cc.label }}</th>
-                <td id='south-form'>{{ canopy_cover_form.south_cc }}</td>
-                <td>{{ canopy_cover_form.south_cc.errors }}</td>
-            </tr>
-
-            <tr>
-                <td>
-                    <div id="canopies">
-                        <div id="canopy-north" class="canopy">
-                            <p class="header">North</p>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-0-0">A</div>
-                            <div class="canopy-square shown" id="square-0-1">B</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-0-2">C</div>
-                            <div class="canopy-square shown" id="square-0-3">D</div>
-                            <div class="canopy-square shown" id="square-0-4">E</div>
-                            <div class="canopy-square shown" id="square-0-5">F</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square shown" id="square-0-6">G</div>
-                            <div class="canopy-square shown" id="square-0-7">H</div>
-                            <div class="canopy-square shown" id="square-0-8">I</div>
-                            <div class="canopy-square shown" id="square-0-9">J</div>
-                            <div class="canopy-square shown" id="square-0-10">K</div>
-                            <div class="canopy-square shown" id="square-0-11">L</div>
-
-                            <div class="canopy-square shown" id="square-0-12">M</div>
-                            <div class="canopy-square shown" id="square-0-13">N</div>
-                            <div class="canopy-square shown" id="square-0-14">O</div>
-                            <div class="canopy-square shown" id="square-0-15">P</div>
-                            <div class="canopy-square shown" id="square-0-16">Q</div>
-                            <div class="canopy-square shown" id="square-0-17">R</div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-0-18">S</div>
-                            <div class="canopy-square shown" id="square-0-19">T</div>
-                            <div class="canopy-square shown" id="square-0-20">U</div>
-                            <div class="canopy-square shown" id="square-0-21">V</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-0-22">W</div>
-                            <div class="canopy-square shown" id="square-0-23">X</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                        </div>
-
-                        <div id="canopy-west" class="canopy">
-                            <p class="header">West</p>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-1-0">A</div>
-                            <div class="canopy-square shown" id="square-1-1">B</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-1-2">C</div>
-                            <div class="canopy-square shown" id="square-1-3">D</div>
-                            <div class="canopy-square shown" id="square-1-4">E</div>
-                            <div class="canopy-square shown" id="square-1-5">F</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square shown" id="square-1-6">G</div>
-                            <div class="canopy-square shown" id="square-1-7">H</div>
-                            <div class="canopy-square shown" id="square-1-8">I</div>
-                            <div class="canopy-square shown" id="square-1-9">J</div>
-                            <div class="canopy-square shown" id="square-1-10">K</div>
-                            <div class="canopy-square shown" id="square-1-11">L</div>
-
-                            <div class="canopy-square shown" id="square-1-12">M</div>
-                            <div class="canopy-square shown" id="square-1-13">N</div>
-                            <div class="canopy-square shown" id="square-1-14">O</div>
-                            <div class="canopy-square shown" id="square-1-15">P</div>
-                            <div class="canopy-square shown" id="square-1-16">Q</div>
-                            <div class="canopy-square shown" id="square-1-17">R</div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-1-18">S</div>
-                            <div class="canopy-square shown" id="square-1-19">T</div>
-                            <div class="canopy-square shown" id="square-1-20">U</div>
-                            <div class="canopy-square shown" id="square-1-21">V</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-1-22">W</div>
-                            <div class="canopy-square shown" id="square-1-23">X</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                        </div>
-
-                        <div id="canopy-east" class="canopy">
-                            <p class="header">East</p>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-2-0">A</div>
-                            <div class="canopy-square shown" id="square-2-1">B</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-2-2">C</div>
-                            <div class="canopy-square shown" id="square-2-3">D</div>
-                            <div class="canopy-square shown" id="square-2-4">E</div>
-                            <div class="canopy-square shown" id="square-2-5">F</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square shown" id="square-2-6">G</div>
-                            <div class="canopy-square shown" id="square-2-7">H</div>
-                            <div class="canopy-square shown" id="square-2-8">I</div>
-                            <div class="canopy-square shown" id="square-2-9">J</div>
-                            <div class="canopy-square shown" id="square-2-10">K</div>
-                            <div class="canopy-square shown" id="square-2-11">L</div>
-
-                            <div class="canopy-square shown" id="square-2-12">M</div>
-                            <div class="canopy-square shown" id="square-2-13">N</div>
-                            <div class="canopy-square shown" id="square-2-14">O</div>
-                            <div class="canopy-square shown" id="square-2-15">P</div>
-                            <div class="canopy-square shown" id="square-2-16">Q</div>
-                            <div class="canopy-square shown" id="square-2-17">R</div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-2-18">S</div>
-                            <div class="canopy-square shown" id="square-2-19">T</div>
-                            <div class="canopy-square shown" id="square-2-20">U</div>
-                            <div class="canopy-square shown" id="square-2-21">V</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-2-22">W</div>
-                            <div class="canopy-square shown" id="square-2-23">X</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                        </div>
-
-                        <div id="canopy-south" class="canopy">
-                            <p class="header">South</p>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-3-0">A</div>
-                            <div class="canopy-square shown" id="square-3-1">B</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-3-2">C</div>
-                            <div class="canopy-square shown" id="square-3-3">D</div>
-                            <div class="canopy-square shown" id="square-3-4">E</div>
-                            <div class="canopy-square shown" id="square-3-5">F</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square shown" id="square-3-6">G</div>
-                            <div class="canopy-square shown" id="square-3-7">H</div>
-                            <div class="canopy-square shown" id="square-3-8">I</div>
-                            <div class="canopy-square shown" id="square-3-9">J</div>
-                            <div class="canopy-square shown" id="square-3-10">K</div>
-                            <div class="canopy-square shown" id="square-3-11">L</div>
-
-                            <div class="canopy-square shown" id="square-3-12">M</div>
-                            <div class="canopy-square shown" id="square-3-13">N</div>
-                            <div class="canopy-square shown" id="square-3-14">O</div>
-                            <div class="canopy-square shown" id="square-3-15">P</div>
-                            <div class="canopy-square shown" id="square-3-16">Q</div>
-                            <div class="canopy-square shown" id="square-3-17">R</div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-3-18">S</div>
-                            <div class="canopy-square shown" id="square-3-19">T</div>
-                            <div class="canopy-square shown" id="square-3-20">U</div>
-                            <div class="canopy-square shown" id="square-3-21">V</div>
-                            <div class="canopy-square hidden"></div>
-
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square shown" id="square-3-22">W</div>
-                            <div class="canopy-square shown" id="square-3-23">X</div>
-                            <div class="canopy-square hidden"></div>
-                            <div class="canopy-square hidden"></div>
-                        </div>
-                    </div>
-                </td>
-            </tr>
-
-            <tr></tr>
-            <tr>
-                <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
-                <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>
-                <td><span class="grey-text" id="percent">0%</span></td>
-                <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
-            </tr>
-        </table> <!-- end canopy cover -->
-        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit'/>
-    </form>
-    {% endif %}
+{% if added %}
+    <strong>{% trans "You have successfully submitted your Canopy Cover Survey." %}</strong>
 
 {% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-    <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
+<h3 align="center">
+    <a href="{% url 'streamwebs:site' site.site_slug %}">
+        {{ site.site_name }}
+    </a>
+</h3>
+<h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
+<form id='canopy_cover_form' method='post'>
+{% csrf_token %}
+    <table> <!-- main cc info table -->
+        <tr>{{ canopy_cover_form.non_field_errors }}</tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.school.label }}</th>
+            <td>{{ canopy_cover_form.school }}</td>
+            <td>{{ canopy_cover_form.school.errors }}</td>
+        </tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.date_time.label }}</th>
+            <td>{{ canopy_cover_form.date_time }}</td>
+            <td>{{ canopy_cover_form.date_time.errors }}</td>
+        </tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.weather.label }}</th>
+            <td>{{ canopy_cover_form.weather }}</td>
+            <td>{{ canopy_cover_form.weather.errors }}</td>
+        </tr>
+        <tr style='display: none'>
+            <th align='left'>{{ canopy_cover_form.north_cc.label }}</th>
+            <td id='north-form'>{{ canopy_cover_form.north_cc }}</td>
+            <td>{{ canopy_cover_form.north_cc.errors }}</td>
+        </tr>
+        <tr style='display: none'>
+            <th align='left'>{{ canopy_cover_form.east_cc.label }}</th>
+            <td id='east-form'>{{ canopy_cover_form.east_cc }}</td>
+            <td>{{ canopy_cover_form.east_cc.errors }}</td>
+        </tr>
+        <tr style='display: none'>
+            <th align='left'>{{ canopy_cover_form.west_cc.label }}</th>
+            <td id='west-form'>{{ canopy_cover_form.west_cc }}</td>
+            <td>{{ canopy_cover_form.west_cc.errors }}</td>
+        </tr>
+        <tr style='display: none'>
+            <th align='left'>{{ canopy_cover_form.south_cc.label }}</th>
+            <td id='south-form'>{{ canopy_cover_form.south_cc }}</td>
+            <td>{{ canopy_cover_form.south_cc.errors }}</td>
+        </tr>
+
+        <tr>
+            <td>
+                <div id="canopies">
+                    <div id="canopy-north" class="canopy">
+                        <p class="header">North</p>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-0-0">A</div>
+                        <div class="canopy-square shown" id="square-0-1">B</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-0-2">C</div>
+                        <div class="canopy-square shown" id="square-0-3">D</div>
+                        <div class="canopy-square shown" id="square-0-4">E</div>
+                        <div class="canopy-square shown" id="square-0-5">F</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square shown" id="square-0-6">G</div>
+                        <div class="canopy-square shown" id="square-0-7">H</div>
+                        <div class="canopy-square shown" id="square-0-8">I</div>
+                        <div class="canopy-square shown" id="square-0-9">J</div>
+                        <div class="canopy-square shown" id="square-0-10">K</div>
+                        <div class="canopy-square shown" id="square-0-11">L</div>
+
+                        <div class="canopy-square shown" id="square-0-12">M</div>
+                        <div class="canopy-square shown" id="square-0-13">N</div>
+                        <div class="canopy-square shown" id="square-0-14">O</div>
+                        <div class="canopy-square shown" id="square-0-15">P</div>
+                        <div class="canopy-square shown" id="square-0-16">Q</div>
+                        <div class="canopy-square shown" id="square-0-17">R</div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-0-18">S</div>
+                        <div class="canopy-square shown" id="square-0-19">T</div>
+                        <div class="canopy-square shown" id="square-0-20">U</div>
+                        <div class="canopy-square shown" id="square-0-21">V</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-0-22">W</div>
+                        <div class="canopy-square shown" id="square-0-23">X</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                    </div>
+
+                    <div id="canopy-west" class="canopy">
+                        <p class="header">West</p>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-1-0">A</div>
+                        <div class="canopy-square shown" id="square-1-1">B</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-1-2">C</div>
+                        <div class="canopy-square shown" id="square-1-3">D</div>
+                        <div class="canopy-square shown" id="square-1-4">E</div>
+                        <div class="canopy-square shown" id="square-1-5">F</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square shown" id="square-1-6">G</div>
+                        <div class="canopy-square shown" id="square-1-7">H</div>
+                        <div class="canopy-square shown" id="square-1-8">I</div>
+                        <div class="canopy-square shown" id="square-1-9">J</div>
+                        <div class="canopy-square shown" id="square-1-10">K</div>
+                        <div class="canopy-square shown" id="square-1-11">L</div>
+
+                        <div class="canopy-square shown" id="square-1-12">M</div>
+                        <div class="canopy-square shown" id="square-1-13">N</div>
+                        <div class="canopy-square shown" id="square-1-14">O</div>
+                        <div class="canopy-square shown" id="square-1-15">P</div>
+                        <div class="canopy-square shown" id="square-1-16">Q</div>
+                        <div class="canopy-square shown" id="square-1-17">R</div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-1-18">S</div>
+                        <div class="canopy-square shown" id="square-1-19">T</div>
+                        <div class="canopy-square shown" id="square-1-20">U</div>
+                        <div class="canopy-square shown" id="square-1-21">V</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-1-22">W</div>
+                        <div class="canopy-square shown" id="square-1-23">X</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                    </div>
+
+                    <div id="canopy-east" class="canopy">
+                        <p class="header">East</p>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-2-0">A</div>
+                        <div class="canopy-square shown" id="square-2-1">B</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-2-2">C</div>
+                        <div class="canopy-square shown" id="square-2-3">D</div>
+                        <div class="canopy-square shown" id="square-2-4">E</div>
+                        <div class="canopy-square shown" id="square-2-5">F</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square shown" id="square-2-6">G</div>
+                        <div class="canopy-square shown" id="square-2-7">H</div>
+                        <div class="canopy-square shown" id="square-2-8">I</div>
+                        <div class="canopy-square shown" id="square-2-9">J</div>
+                        <div class="canopy-square shown" id="square-2-10">K</div>
+                        <div class="canopy-square shown" id="square-2-11">L</div>
+
+                        <div class="canopy-square shown" id="square-2-12">M</div>
+                        <div class="canopy-square shown" id="square-2-13">N</div>
+                        <div class="canopy-square shown" id="square-2-14">O</div>
+                        <div class="canopy-square shown" id="square-2-15">P</div>
+                        <div class="canopy-square shown" id="square-2-16">Q</div>
+                        <div class="canopy-square shown" id="square-2-17">R</div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-2-18">S</div>
+                        <div class="canopy-square shown" id="square-2-19">T</div>
+                        <div class="canopy-square shown" id="square-2-20">U</div>
+                        <div class="canopy-square shown" id="square-2-21">V</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-2-22">W</div>
+                        <div class="canopy-square shown" id="square-2-23">X</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                    </div>
+
+                    <div id="canopy-south" class="canopy">
+                        <p class="header">South</p>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-3-0">A</div>
+                        <div class="canopy-square shown" id="square-3-1">B</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-3-2">C</div>
+                        <div class="canopy-square shown" id="square-3-3">D</div>
+                        <div class="canopy-square shown" id="square-3-4">E</div>
+                        <div class="canopy-square shown" id="square-3-5">F</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square shown" id="square-3-6">G</div>
+                        <div class="canopy-square shown" id="square-3-7">H</div>
+                        <div class="canopy-square shown" id="square-3-8">I</div>
+                        <div class="canopy-square shown" id="square-3-9">J</div>
+                        <div class="canopy-square shown" id="square-3-10">K</div>
+                        <div class="canopy-square shown" id="square-3-11">L</div>
+
+                        <div class="canopy-square shown" id="square-3-12">M</div>
+                        <div class="canopy-square shown" id="square-3-13">N</div>
+                        <div class="canopy-square shown" id="square-3-14">O</div>
+                        <div class="canopy-square shown" id="square-3-15">P</div>
+                        <div class="canopy-square shown" id="square-3-16">Q</div>
+                        <div class="canopy-square shown" id="square-3-17">R</div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-3-18">S</div>
+                        <div class="canopy-square shown" id="square-3-19">T</div>
+                        <div class="canopy-square shown" id="square-3-20">U</div>
+                        <div class="canopy-square shown" id="square-3-21">V</div>
+                        <div class="canopy-square hidden"></div>
+
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square shown" id="square-3-22">W</div>
+                        <div class="canopy-square shown" id="square-3-23">X</div>
+                        <div class="canopy-square hidden"></div>
+                        <div class="canopy-square hidden"></div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+
+        <tr></tr>
+        <tr>
+            <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
+            <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>
+            <td><span class="grey-text" id="percent">0%</span></td>
+            <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
+        </tr>
+    </table> <!-- end canopy cover -->
+    <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit'/>
+</form>
 {% endif %}
+
 {% endblock %}
 
 {% block scripts %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -17,136 +17,131 @@
 {% endblock %}
 {% block content %}
 <div class="container">
-    {% if user.is_authenticated %}
-        {% if added %}
-        <strong>{% trans "You have successfully submitted your Macroinvertebrate data sheet." %}.</strong>
-
-        {% else %}
-        <h3 align="center">
-            <a href="{% url 'streamwebs:site' site.site_slug %}">
-                {{ site.site_name }}
-            </a>
-        </h3>
-        <h4 align="center">{% trans 'New Macroinvertebrate Sampling' %}</h4>
-        <form id='macro_form' method='post' action='{{ request.path }}'>
-            {% csrf_token %}
-
-            <div class="row">
-                <div class="col s6">
-                    <p>{{ macro_form.school.label }}</p>
-                    <p>{{ macro_form.school }}</p>
-                    <p>{{ macro_form.school.errors }}</p>
-                </div>
-                <div class="col s6">
-                    <p>{{ macro_form.time_spent.label }} (minutes)</p>
-                    <p>{{ macro_form.time_spent }}</p>
-                    <p>{{ macro_form.time_spent.errors }}</p>
-                </div>
-                <div class="col s6">
-                    <p>{{ macro_form.date_time.label }}</p>
-                    <p>{{ macro_form.date_time }}</p>
-                    <p>{{ macro_form.date_time.errors }}</p>
-                </div>
-                <div class="col s6">
-                    <p>{{ macro_form.num_people.label }}</p>
-                    <p>{{ macro_form.num_people }}</p>
-                    <p>{{ macro_form.num_people.errors }}</p>
-                </div>
-                <div class="col s6">
-                    <p>{{ macro_form.weather.label }}</p>
-                    <p>{{ macro_form.weather }}</p>
-                    <p>{{ macro_form.weather.errors }}</p>
-                </div>
-                <div class="col s6">
-                    <p>{{ macro_form.water_type.label }}</p>
-                    <p>{{ macro_form.water_type }}</p>
-                    <p>{{ macro_form.water_type.errors }}</p>
-                </div>
-                <div class="col s12">
-                    <p>{{ macro_form.notes.label }}</p>
-                    <p>{{ macro_form.notes }}</p>
-                    <p>{{ macro_form.notes.errors }}</p>
-                </div>
-            </div>
-
-            <div class="row">
-                <h5 align=center>Sensitivity to pollution</h5>
-                <div class="col s4">
-                    <h6 align=center>Sensitive/intolerant</h6>
-                    <table>
-                        {% for bug in intolerant %}
-                        <tr>
-                            <td>
-                                {{ bug.label }}<br>
-                                {% with bug.label|lower|strtoul|slashtoul as buggy %}
-                                    {% with 'streamwebs/images/macroinvertebrates/macro_'|add:buggy|add:'.png' as bug_img %}
-                                        <img src="{% static bug_img %}">
-                                    {% endwith %}
-                                {% endwith %}
-                            </td>
-                            <td>
-                                {{ bug }}
-                                {{ bug.errors }}
-                            </td>
-                        </tr>
-                        {% endfor %}
-
-                    </table>
-                </div>  <!-- end sensitive/intolerant -->
-
-                <div class="col s4">
-                    <h6 align=center>Somewhat sensitive</h6>
-                    <table>
-                        {% for bug in somewhat %}
-                        <tr>
-                            <td>
-                                {{ bug.label }}<br>
-                                {% with bug.label|lower|strtoul|slashtoul as buggy %}
-                                    {% with 'streamwebs/images/macroinvertebrates/macro_'|add:buggy|add:'.png' as bug_img %}
-                                        <img src="{% static bug_img %}">
-                                    {% endwith %}
-                                {% endwith %}
-                            </td>
-                            <td>
-                                {{ bug }}
-                                {{ bug.errors }}
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </table>
-                </div>  <!-- end somewhat sensitive -->
-
-                <div class="col s4">
-                    <h6 align=center>Tolerant</h6>
-                    <table>
-                        {% for bug in tolerant %}
-                        <tr>
-                            <td>
-                                {{ bug.label }}</br>
-                                {% with bug.label|lower|strtoul|slashtoul as buggy %}
-                                    {% with 'streamwebs/images/macroinvertebrates/macro_'|add:buggy|add:'.png' as bug_img %}
-                                        <img src="{% static bug_img %}">
-                                    {% endwith %}
-                                {% endwith %}
-                            </td>
-                            <td>
-                                {{ bug }}
-                                {{ bug.errors }}
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </table>
-                </div>  <!-- end tolerant -->
-            </div> <!-- end macros row -->
-
-            <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit' />
-        </form>
-        {% endif %}
+    {% if added %}
+    <strong>{% trans "You have successfully submitted your Macroinvertebrate data sheet." %}.</strong>
 
     {% else %}
-        <p>{% trans "You must be logged in to submit data." %}</p>
-        <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
+    <h4 align="center">{% trans 'New Macroinvertebrate Sampling' %}</h4>
+    <form id='macro_form' method='post' action='{{ request.path }}'>
+        {% csrf_token %}
+
+        <div class="row">
+            <div class="col s6">
+                <p>{{ macro_form.school.label }}</p>
+                <p>{{ macro_form.school }}</p>
+                <p>{{ macro_form.school.errors }}</p>
+            </div>
+            <div class="col s6">
+                <p>{{ macro_form.time_spent.label }} (minutes)</p>
+                <p>{{ macro_form.time_spent }}</p>
+                <p>{{ macro_form.time_spent.errors }}</p>
+            </div>
+            <div class="col s6">
+                <p>{{ macro_form.date_time.label }}</p>
+                <p>{{ macro_form.date_time }}</p>
+                <p>{{ macro_form.date_time.errors }}</p>
+            </div>
+            <div class="col s6">
+                <p>{{ macro_form.num_people.label }}</p>
+                <p>{{ macro_form.num_people }}</p>
+                <p>{{ macro_form.num_people.errors }}</p>
+            </div>
+            <div class="col s6">
+                <p>{{ macro_form.weather.label }}</p>
+                <p>{{ macro_form.weather }}</p>
+                <p>{{ macro_form.weather.errors }}</p>
+            </div>
+            <div class="col s6">
+                <p>{{ macro_form.water_type.label }}</p>
+                <p>{{ macro_form.water_type }}</p>
+                <p>{{ macro_form.water_type.errors }}</p>
+            </div>
+            <div class="col s12">
+                <p>{{ macro_form.notes.label }}</p>
+                <p>{{ macro_form.notes }}</p>
+                <p>{{ macro_form.notes.errors }}</p>
+            </div>
+        </div>
+
+        <div class="row">
+            <h5 align=center>Sensitivity to pollution</h5>
+            <div class="col s4">
+                <h6 align=center>Sensitive/intolerant</h6>
+                <table>
+                    {% for bug in intolerant %}
+                    <tr>
+                        <td>
+                            {{ bug.label }}<br>
+                            {% with bug.label|lower|strtoul|slashtoul as buggy %}
+                                {% with 'streamwebs/images/macroinvertebrates/macro_'|add:buggy|add:'.png' as bug_img %}
+                                    <img src="{% static bug_img %}">
+                                {% endwith %}
+                            {% endwith %}
+                        </td>
+                        <td>
+                            {{ bug }}
+                            {{ bug.errors }}
+                        </td>
+                    </tr>
+                    {% endfor %}
+
+                </table>
+            </div>  <!-- end sensitive/intolerant -->
+
+            <div class="col s4">
+                <h6 align=center>Somewhat sensitive</h6>
+                <table>
+                    {% for bug in somewhat %}
+                    <tr>
+                        <td>
+                            {{ bug.label }}<br>
+                            {% with bug.label|lower|strtoul|slashtoul as buggy %}
+                                {% with 'streamwebs/images/macroinvertebrates/macro_'|add:buggy|add:'.png' as bug_img %}
+                                    <img src="{% static bug_img %}">
+                                {% endwith %}
+                            {% endwith %}
+                        </td>
+                        <td>
+                            {{ bug }}
+                            {{ bug.errors }}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </table>
+            </div>  <!-- end somewhat sensitive -->
+
+            <div class="col s4">
+                <h6 align=center>Tolerant</h6>
+                <table>
+                    {% for bug in tolerant %}
+                    <tr>
+                        <td>
+                            {{ bug.label }}</br>
+                            {% with bug.label|lower|strtoul|slashtoul as buggy %}
+                                {% with 'streamwebs/images/macroinvertebrates/macro_'|add:buggy|add:'.png' as bug_img %}
+                                    <img src="{% static bug_img %}">
+                                {% endwith %}
+                            {% endwith %}
+                        </td>
+                        <td>
+                            {{ bug }}
+                            {{ bug.errors }}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </table>
+            </div>  <!-- end tolerant -->
+        </div> <!-- end macros row -->
+
+        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit' />
+    </form>
     {% endif %}
+
     </div>  <!-- end container -->
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
@@ -5,20 +5,15 @@
 {% block title %}{% trans "New photo point" %}{% endblock %}
 {% block body_title %}{% trans "Add a new photo point for camera point" %}{% endblock %}
 {% block content %}
-    {% if user.is_authenticated %}
-        {% if added %}
-        <strong>{% trans "You have successfully added a new photo point" %}</strong>
-        {% else %}
-        <form id='pp_form' method='post' enctype='multipart/form-data'>
-            {% csrf_token %}
-            {{ pp_form.as_p }}
-            {{ ppi_formset.as_p }}
-            <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit' />
-        </form>
-        {% endif %}
-
+    {% if added %}
+    <strong>{% trans "You have successfully added a new photo point" %}</strong>
     {% else %}
-        <p>{% trans "You must be logged in to submit data." %}</p>
-        <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
+    <form id='pp_form' method='post' enctype='multipart/form-data'>
+        {% csrf_token %}
+        {{ pp_form.as_p }}
+        {{ ppi_formset.as_p }}
+        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit' />
+    </form>
     {% endif %}
+
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -18,118 +18,113 @@
 {% endblock%}
 
 {% block content %}
-    <div class="container">
-    {% if user.is_authenticated %}
-    {% if added %}
-    <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
+<div class="container">
+{% if added %}
+<strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
 
-    {% else %}
-        <h3 align ="center">
-            <a href="{% url 'streamwebs:site' site.site_slug %}">
-                {{ site.site_name }}
-            </a>
-        </h3>
+{% else %}
+    <h3 align ="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
 
-        <h4 align="center">{% trans 'New Riparian Area Transect Sampling' %}</h4>
+    <h4 align="center">{% trans 'New Riparian Area Transect Sampling' %}</h4>
 
-        <form id='rip_trans_form' method='post'>
-            {% csrf_token %}
-            <tr>{{ transect_form.non_field_errors }}</tr>
+    <form id='rip_trans_form' method='post'>
+        {% csrf_token %}
+        <tr>{{ transect_form.non_field_errors }}</tr>
 
-            <div class="row">
+        <div class="row">
+            <div class="input-field">
+                {{ transect_form.school.label }}
+                {{ transect_form.school.errors | striptags }}
+                {{ transect_form.school }}
+        </div>
+
+        <div class="row">
+            <div class="col s6">
                 <div class="input-field">
-                    {{ transect_form.school.label }}
-                    {{ transect_form.school.errors | striptags }}
-                    {{ transect_form.school }}
-            </div>
-
-            <div class="row">
-                <div class="col s6">
-                    <div class="input-field">
-                        <label for="{{ transect_form.date_time.id_for_label }}">
-                            {{ transect_form.date_time.label }}
-                        </label>
-                        {{ transect_form.date_time.errors | striptags }}
-                        {{ transect_form.date_time }}
-                    </div>
-                </div>
-
-                <div class="col s6">
-                    <div class="input-field">
-                        <label for="{{ transect_form.weather.id_for_label }}">
-                            {{ transect_form.weather.label }}
-                        </label>
-                        {{ transect_form.weather.errors | striptags }}
-                        {{ transect_form.weather }}
-                    </div>
-                </div>
-            </div>
-
-            <div class"row">
-                <div class="input-field">
-                    <label for="{{ transect_form.slope.id_for_label }}">
-                        {{ transect_form.slope.label }}
+                    <label for="{{ transect_form.date_time.id_for_label }}">
+                        {{ transect_form.date_time.label }}
                     </label>
-                    {{ transect_form.slope.errors | striptags }}
-                    {{ transect_form.slope }}
+                    {{ transect_form.date_time.errors | striptags }}
+                    {{ transect_form.date_time }}
                 </div>
             </div>
 
-            <br>
-            <div class="divider"></div>
-            <br>
-
-            {{ zone_formset.management_form }}
-            <table> <!-- zones subtable -->
-                <tr>
-                    <th>{{ 'zone'|get_zone_labels }}</th>
-                    <th>{{ 'conifers'|get_zone_labels }}</th>
-                    <th>{{ 'hardwoods'|get_zone_labels }}</th>
-                    <th>{{ 'shrubs'|get_zone_labels }}</th>
-                    <th>{{ 'comments'|get_zone_labels }}</th>
-                </tr>
-            {% for zone_form in zone_formset %}
-                <tr>
-                    <th></th>
-                    <td>{{ zone_form.conifers.errors }}</td>
-                    <td>{{ zone_form.hardwoods.errors }}</td>
-                    <td>{{ zone_form.shrubs.errors }}</td>
-                    <td>{{ zone_form.comments.errors }}</td>
-                </tr>
-                <tr>
-                    <th>
-                        {{ forloop.counter0|plus_one }}<br>
-                        {{ forloop.counter0|get_zone }}
-                    </th>
-                    <td>{{ zone_form.conifers }}</td>
-                    <td>{{ zone_form.hardwoods }}</td>
-                    <td>{{ zone_form.shrubs }}</td>
-                    <td>{{ zone_form.comments }}</td>
-                </tr>
-            {% endfor %}
-            </table> <!-- end zones subtable -->
-
-            <div class="divider"></div>
-            <br>
-
-            <div class="row">
+            <div class="col s6">
                 <div class="input-field">
-                    <label for="{{ transect_form.notes.id_for_label }}">
-                        {{ transect_form.notes.label }}
+                    <label for="{{ transect_form.weather.id_for_label }}">
+                        {{ transect_form.weather.label }}
                     </label>
-                    {{ transect_form.notes.errors | striptags }}
-                    {{ transect_form.notes }}
+                    {{ transect_form.weather.errors | striptags }}
+                    {{ transect_form.weather }}
                 </div>
             </div>
+        </div>
+
+        <div class"row">
+            <div class="input-field">
+                <label for="{{ transect_form.slope.id_for_label }}">
+                    {{ transect_form.slope.label }}
+                </label>
+                {{ transect_form.slope.errors | striptags }}
+                {{ transect_form.slope }}
+            </div>
+        </div>
+
+        <br>
+        <div class="divider"></div>
+        <br>
+
+        {{ zone_formset.management_form }}
+        <table> <!-- zones subtable -->
+            <tr>
+                <th>{{ 'zone'|get_zone_labels }}</th>
+                <th>{{ 'conifers'|get_zone_labels }}</th>
+                <th>{{ 'hardwoods'|get_zone_labels }}</th>
+                <th>{{ 'shrubs'|get_zone_labels }}</th>
+                <th>{{ 'comments'|get_zone_labels }}</th>
+            </tr>
+        {% for zone_form in zone_formset %}
+            <tr>
+                <th></th>
+                <td>{{ zone_form.conifers.errors }}</td>
+                <td>{{ zone_form.hardwoods.errors }}</td>
+                <td>{{ zone_form.shrubs.errors }}</td>
+                <td>{{ zone_form.comments.errors }}</td>
+            </tr>
+            <tr>
+                <th>
+                    {{ forloop.counter0|plus_one }}<br>
+                    {{ forloop.counter0|get_zone }}
+                </th>
+                <td>{{ zone_form.conifers }}</td>
+                <td>{{ zone_form.hardwoods }}</td>
+                <td>{{ zone_form.shrubs }}</td>
+                <td>{{ zone_form.comments }}</td>
+            </tr>
+        {% endfor %}
+        </table> <!-- end zones subtable -->
+
+        <div class="divider"></div>
+        <br>
+
+        <div class="row">
+            <div class="input-field">
+                <label for="{{ transect_form.notes.id_for_label }}">
+                    {{ transect_form.notes.label }}
+                </label>
+                {{ transect_form.notes.errors | striptags }}
+                {{ transect_form.notes }}
+            </div>
+        </div>
 
     <input class="btn waves-effect waves-light teal darken-4" type='submit' value='Submit' />
     </form>
 {% endif %}
 
-{% else %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-    <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
-{% endif %}
 </div>
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
@@ -18,121 +18,116 @@
 {% endblock %}}
 
 {% block content %}
-    <div class="container">
-        {% if user.is_authenticated %}
-            {% if added %}
-                <strong>{% trans "You have successfully submitted your Soil Survey data sheet." %}</strong>
+<div class="container">
+    {% if added %}
+        <strong>{% trans "You have successfully submitted your Soil Survey data sheet." %}</strong>
 
-            {% else %}
-                <h3 align="center">
-                    <a href="{% url 'streamwebs:site' site.site_slug %}">
-                        {{ site.site_name }}
-                    </a>
-                </h3>
-                <h4 align="center">{% trans "New Riparian Soil Survey" %}</h4>
-                <form id='soil_from' method='post' action='{{ request.path }}'>
-                    {% csrf_token %}
+    {% else %}
+        <h3 align="center">
+            <a href="{% url 'streamwebs:site' site.site_slug %}">
+                {{ site.site_name }}
+            </a>
+        </h3>
+        <h4 align="center">{% trans "New Riparian Soil Survey" %}</h4>
+        <form id='soil_from' method='post' action='{{ request.path }}'>
+            {% csrf_token %}
 
-                <div class="row">
-                    <div class="col s6">
-                        <div class ="input-field">
-                            <p>{{ soil_form.school.label }}</p>
-                            <p>{{ soil_form.school.errors | striptags }}</p>
-                            <p>{{ soil_form.school }}</p>
-                        </div>
-                    </div>
-
-                    <div class="col s6">
-                        <p>{{ soil_form.date.label }}</p>
-                        <p>{{ soil_form.date.errors | striptags }}</p>
-                        <p>{{ soil_form.date }}</p>
-                    </div>
-
-                    <div class="col s12">
-                        <p>{{ soil_form.weather.label }}</p>
-                        <p>{{ soil_form.weather.errors | striptags }}</p>
-                        <p>{{ soil_form.weather }}</p>
-                    </div>
+        <div class="row">
+            <div class="col s6">
+                <div class ="input-field">
+                    <p>{{ soil_form.school.label }}</p>
+                    <p>{{ soil_form.school.errors | striptags }}</p>
+                    <p>{{ soil_form.school }}</p>
                 </div>
+            </div>
 
-                <!-- Container so that radio buttons render vertically -->
-                <div class="container">
-                    <div class="row">
-                        <div class="col s4 pull-s2">
-                            <p>Landscape Position</p>
-                            {{ soil_form.landscape_pos.errors| striptags }}
-                            <div class="input-field">
-                                {% for radio in soil_form.landscape_pos %}
-                                    {{ radio.tag }}
-                                    <label for="{{radio.id_for_label }}">
-                                        {{radio.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        <div class="col s4 push-s1">
-                            <p>Cover Type</p>
-                            {{ soil_form.cover_type.errors| striptags }}
-                            <div class="input-field">
-                                {% for radio in soil_form.cover_type %}
-                                    {{ radio.tag }}
-                                    <label for="{{radio.id_for_label }}">
-                                        {{radio.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        <div class="col s4 push-s3">
-                            <p>Land Use</p>
-                            {{ soil_form.land_use.errors| striptags }}
-                            <div class="input-field">
-                                {% for radio in soil_form.land_use %}
-                                    {{ radio.tag }}
-                                    <label for="{{radio.id_for_label }}">
-                                        {{radio.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <div class="col s6">
+                <p>{{ soil_form.date.label }}</p>
+                <p>{{ soil_form.date.errors | striptags }}</p>
+                <p>{{ soil_form.date }}</p>
+            </div>
 
-                <br />
-                <div class="row">
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ soil_form.soil_type.label }}
-                            {{ soil_form.soil_type.errors | striptags }}
-                            {{ soil_form.soil_type }}
-                        </div>
-                    </div>
+            <div class="col s12">
+                <p>{{ soil_form.weather.label }}</p>
+                <p>{{ soil_form.weather.errors | striptags }}</p>
+                <p>{{ soil_form.weather }}</p>
+            </div>
+        </div>
 
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ soil_form.distance.label }}
-                            {{ soil_form.distance.errors | striptags }}
-                            {{ soil_form.distance }}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="row">
+        <!-- Container so that radio buttons render vertically -->
+        <div class="container">
+            <div class="row">
+                <div class="col s4 pull-s2">
+                    <p>Landscape Position</p>
+                    {{ soil_form.landscape_pos.errors| striptags }}
                     <div class="input-field">
-                        {{soil_form.site_char.label }}
-                        {{ soil_form.site_char.errors | striptags }}
-                        {{ soil_form.site_char }}
+                        {% for radio in soil_form.landscape_pos %}
+                            {{ radio.tag }}
+                            <label for="{{radio.id_for_label }}">
+                                {{radio.choice_label }}
+                            </label>
+                        {% endfor %}
                     </div>
                 </div>
+                <div class="col s4 push-s1">
+                    <p>Cover Type</p>
+                    {{ soil_form.cover_type.errors| striptags }}
+                    <div class="input-field">
+                        {% for radio in soil_form.cover_type %}
+                            {{ radio.tag }}
+                            <label for="{{radio.id_for_label }}">
+                                {{radio.choice_label }}
+                            </label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col s4 push-s3">
+                    <p>Land Use</p>
+                    {{ soil_form.land_use.errors| striptags }}
+                    <div class="input-field">
+                        {% for radio in soil_form.land_use %}
+                            {{ radio.tag }}
+                            <label for="{{radio.id_for_label }}">
+                                {{radio.choice_label }}
+                            </label>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
 
-                <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit' />
-            </form>
+        <br />
+        <div class="row">
+            <div class="col s6">
+                <div class="input-field">
+                    {{ soil_form.soil_type.label }}
+                    {{ soil_form.soil_type.errors | striptags }}
+                    {{ soil_form.soil_type }}
+                </div>
+            </div>
 
-            {% endif %}
-        {% else %}
-            <p>{% trans "You must be logged in to submit data." %}</p>
-            <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
-        {% endif %}
-    </div>  <!-- end container -->
+            <div class="col s6">
+                <div class="input-field">
+                    {{ soil_form.distance.label }}
+                    {{ soil_form.distance.errors | striptags }}
+                    {{ soil_form.distance }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="input-field">
+                {{soil_form.site_char.label }}
+                {{ soil_form.site_char.errors | striptags }}
+                {{ soil_form.site_char }}
+            </div>
+        </div>
+
+        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit' />
+    </form>
+
+    {% endif %}
+</div>  <!-- end container -->
 
 {% endblock %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -11,354 +11,349 @@
 {% endblock %}
 
 {% block content %}
-{% if not user.is_authenticated and editable %}
-    <p>{% trans "You must be logged in to submit data." %}</p>
-    <a href="{% url 'streamwebs:login' %}">{% trans "Log in here." %}</a>
-{% else %}
-    {% if user.is_authenticated and added %}
-        <strong>Success!</strong>
+{% if added %}
+    <strong>Success!</strong>
 
-        <!-- Display errors, if any (should be improved/more CSS friendly) -->
-        <!-- {% for field in wq_form %}
-            {% if field.errors %}
-                <br>{{ field.label }}</br>
-                {% for error in field.errors %}
-                    <br>...{{ error }}</br>
-                {% endfor %}
-            {% endif %}
-        {% endfor %}
-        {% for field in sample_formset %}
-            {% if field.errors %}
-                <br>{{ field.label }}</br>
-                {% for error in field.errors %}
-                    <br>,,,{{ error }}</br>
-                {% endfor %}
-            {% endif %}
-        {% endfor %} -->
-    {% endif %}
-
-    <div class="container">
-        <h3 align="center">
-            <a href="{% url 'streamwebs:site' site.site_slug %}">
-                {{site.site_name}}
-            </a>
-        </h3>
-        <h4 align="center">{% trans 'New Water Quality Sampling' %}</h4>
-        <form id="water_quality_form" action="" method="POST">
-            {% csrf_token %}
-            <div class="infogroup">
-                <p>{{ wq_form.site.errors | striptags }}</p>
-                <div class="row">
-                    <div class="col s6">
-                        <div class="input-field">
-                            <label for="{{ wq_form.date.id_for_label }}">{{ wq_form.date.label }}</label>
-
-                            {{ wq_form.date.errors | striptags }}
-                            {{ wq_form.date }}
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ wq_form.school.label }}
-
-                            {{ wq_form.school.errors | striptags }}
-                            {{ wq_form.school }}
-                        </div>
-                    </div>
-                    <div class="col s6">
-                        <div class="input-field">
-                            {{ wq_form.DEQ_dq_level.label }}
-
-                            {{ wq_form.DEQ_dq_level.errors | striptags }}
-                            {{ wq_form.DEQ_dq_level }}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="row">
-                    <div class="col s6">
-                        <div class="input-field">
-                            <label for="{{ wq_form.latitude.id_for_label }}">{{ wq_form.latitude.label }}</label>
-
-                            {{ wq_form.latitude.errors | striptags }}
-                            {{ wq_form.latitude }}
-                        </div>
-                    </div>
-
-                    <div class="col s6">
-                        <div class="input-field">
-                            <label for="{{ wq_form.longitude.id_for_label }}">{{ wq_form.longitude.label }}</label>
-
-                            {{ wq_form.longitude.errors | striptags }}
-                            {{ wq_form.longitude }}
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col s4">
-                    <p>{{ wq_form.fish_present.label }}</p>
-                    {{ wq_form.fish_present.errors | striptags }}
-                    <div class="input-field">
-                        {% for radio in wq_form.fish_present %}
-                            {{ radio.tag }}
-                            <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                        {% endfor %}
-                    </div>
-                </div>
-
-                <div class="col s4">
-                    <p>{{ wq_form.live_fish.label }}</p>
-
-                    {{ wq_form.live_fish.errors | striptags }}
-                    {{ wq_form.live_fish }}
-                </div>
-
-                <div class="col s4">
-                    <p>{{ wq_form.dead_fish.label }}</p>
-
-                    {{ wq_form.dead_fish.errors | striptags }}
-                    {{ wq_form.dead_fish }}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col s6">
-                    <p>{{ wq_form.water_temp_unit.label }}</p>
-                    {{ wq_form.water_temp_unit.errors | striptags }}
-                    <div class="input-field">
-                        {% for radio in wq_form.water_temp_unit %}
-                            {{ radio.tag }}
-                            <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                        {% endfor %}
-                    </div>
-                </div>
-
-                <div class="col s6">
-                    <p>{{ wq_form.air_temp_unit.label }}</p>
-                    {{ wq_form.air_temp_unit.errors | striptags }}
-                    <div class="input-field">
-                        {% for radio in wq_form.air_temp_unit %}
-                            {{ radio.tag }}
-                            <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-
-            <table>
-                {{ sample_formset.management_form }}
-
-                <thead>
-                    <th data-field="test"></th>
-                    <th data-field="sample1">Sample 1</th>
-                    <th data-field="sample2">Sample 2</th>
-                    <th data-field="sample3">Sample 3</th>
-                    <th data-field="sample4">Sample 4</th>
-                </thead>
-
-                <tbody>
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.water_temperature.label }}</td>
-                            {% endif %}
-
-                            <td>
-                                <div class="input-field">{{ sample.water_temperature }}</div>
-                                {{ sample.water_temp_tool.errors | striptags }}
-
-                                {% for radio in sample.water_temp_tool %}
-                                    {{ radio.tag }}
-                                    <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                {% endfor %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.air_temperature.label }}</td>
-                            {% endif %}
-
-                            <td>
-                                <div class="input-field">{{ sample.air_temperature }}</div>
-                                {{ sample.air_temp_tool.errors | striptags }}
-
-                                {% for radio in sample.air_temp_tool %}
-                                    {{ radio.tag }}
-                                    <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                {% endfor %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.dissolved_oxygen.label }}</td>
-                            {% endif %}
-
-                            <td>
-                                <div class="input-field">{{ sample.dissolved_oxygen }}</div>
-                                {{ sample.oxygen_tool.errors | striptags }}
-
-                                {% for radio in sample.oxygen_tool %}
-                                    {{ radio.tag }}
-                                    <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                {% endfor %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.pH.label }}</td>
-                            {% endif %}
-
-                            <td>
-                                <div class="input-field">{{ sample.pH }}</div>
-                                {{ sample.pH_tool.errors | striptags }}
-
-                                {% for radio in sample.pH_tool %}
-                                    {{ radio.tag }}
-                                    <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                {% endfor %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.turbidity.label }}</td>
-                            {% endif %}
-
-                            <td>
-                                <div class="input-field">{{ sample.turbidity }}</div>
-                                {{ sample.turbid_tool.errors | striptags }}
-
-                                {% for radio in sample.turbid_tool %}
-                                    {{ radio.tag }}
-                                    <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                {% endfor %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.salinity.label }}</td>
-                            {% endif %}
-
-                            <td>
-                                <div class="input-field">{{ sample.salinity }}</div>
-                                {{ sample.salt_tool.errors | striptags }}
-
-                                {% for radio in sample.salt_tool %}
-                                    {{ radio.tag }}
-                                    <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                {% endfor %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr class="collapse-btn">
-                        <th>Additional parameters <i class="material-icons">arrow_drop_down</i></th>
-                    </tr>
-                </tbody>
-            </table>
-
-            <div class="collapse">
-                <table>
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.conductivity.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.conductivity }}</div></td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.total_solids.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.total_solids }}</div></td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.bod.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.bod }}</div></td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.ammonia.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.ammonia }}</div></td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.nitrite.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.nitrite }}</div></td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.phosphates.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.phosphates }}</div></td>
-                        {% endfor %}
-                    </tr>
-
-                    <tr>
-                        {% for sample in sample_formset %}
-                            {% if forloop.first %}
-                                <td>{{ sample.fecal_coliform.label }}</td>
-                            {% endif %}
-
-                            <td><div class="input-field">{{ sample.fecal_coliform }}</div></td>
-                        {% endfor %}
-                    </tr>
-                </table>
-            </div>
-
-            <div class="input-field">
-                <label for="{{ wq_form.notes.id_for_label }}">{{ wq_form.notes.label }}</label>
-                {{ wq_form.notes.errors | striptags }}
-                {{ wq_form.notes }}
-            </div>
-
-            {% if editable %}
-                <input class="btn waves-effect waves-light teal darken-4" type="submit" value="Submit">
-            {% endif %}
-        </form>
-    </div>
+    <!-- Display errors, if any (should be improved/more CSS friendly) -->
+    <!-- {% for field in wq_form %}
+        {% if field.errors %}
+            <br>{{ field.label }}</br>
+            {% for error in field.errors %}
+                <br>...{{ error }}</br>
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    {% for field in sample_formset %}
+        {% if field.errors %}
+            <br>{{ field.label }}</br>
+            {% for error in field.errors %}
+                <br>,,,{{ error }}</br>
+            {% endfor %}
+        {% endif %}
+    {% endfor %} -->
 {% endif %}
+
+<div class="container">
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{site.site_name}}
+        </a>
+    </h3>
+    <h4 align="center">{% trans 'New Water Quality Sampling' %}</h4>
+    <form id="water_quality_form" action="" method="POST">
+        {% csrf_token %}
+        <div class="infogroup">
+            <p>{{ wq_form.site.errors | striptags }}</p>
+            <div class="row">
+                <div class="col s6">
+                    <div class="input-field">
+                        <label for="{{ wq_form.date.id_for_label }}">{{ wq_form.date.label }}</label>
+
+                        {{ wq_form.date.errors | striptags }}
+                        {{ wq_form.date }}
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col s6">
+                    <div class="input-field">
+                        {{ wq_form.school.label }}
+
+                        {{ wq_form.school.errors | striptags }}
+                        {{ wq_form.school }}
+                    </div>
+                </div>
+                <div class="col s6">
+                    <div class="input-field">
+                        {{ wq_form.DEQ_dq_level.label }}
+
+                        {{ wq_form.DEQ_dq_level.errors | striptags }}
+                        {{ wq_form.DEQ_dq_level }}
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col s6">
+                    <div class="input-field">
+                        <label for="{{ wq_form.latitude.id_for_label }}">{{ wq_form.latitude.label }}</label>
+
+                        {{ wq_form.latitude.errors | striptags }}
+                        {{ wq_form.latitude }}
+                    </div>
+                </div>
+
+                <div class="col s6">
+                    <div class="input-field">
+                        <label for="{{ wq_form.longitude.id_for_label }}">{{ wq_form.longitude.label }}</label>
+
+                        {{ wq_form.longitude.errors | striptags }}
+                        {{ wq_form.longitude }}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col s4">
+                <p>{{ wq_form.fish_present.label }}</p>
+                {{ wq_form.fish_present.errors | striptags }}
+                <div class="input-field">
+                    {% for radio in wq_form.fish_present %}
+                        {{ radio.tag }}
+                        <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                    {% endfor %}
+                </div>
+            </div>
+
+            <div class="col s4">
+                <p>{{ wq_form.live_fish.label }}</p>
+
+                {{ wq_form.live_fish.errors | striptags }}
+                {{ wq_form.live_fish }}
+            </div>
+
+            <div class="col s4">
+                <p>{{ wq_form.dead_fish.label }}</p>
+
+                {{ wq_form.dead_fish.errors | striptags }}
+                {{ wq_form.dead_fish }}
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col s6">
+                <p>{{ wq_form.water_temp_unit.label }}</p>
+                {{ wq_form.water_temp_unit.errors | striptags }}
+                <div class="input-field">
+                    {% for radio in wq_form.water_temp_unit %}
+                        {{ radio.tag }}
+                        <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                    {% endfor %}
+                </div>
+            </div>
+
+            <div class="col s6">
+                <p>{{ wq_form.air_temp_unit.label }}</p>
+                {{ wq_form.air_temp_unit.errors | striptags }}
+                <div class="input-field">
+                    {% for radio in wq_form.air_temp_unit %}
+                        {{ radio.tag }}
+                        <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+
+        <table>
+            {{ sample_formset.management_form }}
+
+            <thead>
+                <th data-field="test"></th>
+                <th data-field="sample1">Sample 1</th>
+                <th data-field="sample2">Sample 2</th>
+                <th data-field="sample3">Sample 3</th>
+                <th data-field="sample4">Sample 4</th>
+            </thead>
+
+            <tbody>
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.water_temperature.label }}</td>
+                        {% endif %}
+
+                        <td>
+                            <div class="input-field">{{ sample.water_temperature }}</div>
+                            {{ sample.water_temp_tool.errors | striptags }}
+
+                            {% for radio in sample.water_temp_tool %}
+                                {{ radio.tag }}
+                                <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.air_temperature.label }}</td>
+                        {% endif %}
+
+                        <td>
+                            <div class="input-field">{{ sample.air_temperature }}</div>
+                            {{ sample.air_temp_tool.errors | striptags }}
+
+                            {% for radio in sample.air_temp_tool %}
+                                {{ radio.tag }}
+                                <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.dissolved_oxygen.label }}</td>
+                        {% endif %}
+
+                        <td>
+                            <div class="input-field">{{ sample.dissolved_oxygen }}</div>
+                            {{ sample.oxygen_tool.errors | striptags }}
+
+                            {% for radio in sample.oxygen_tool %}
+                                {{ radio.tag }}
+                                <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.pH.label }}</td>
+                        {% endif %}
+
+                        <td>
+                            <div class="input-field">{{ sample.pH }}</div>
+                            {{ sample.pH_tool.errors | striptags }}
+
+                            {% for radio in sample.pH_tool %}
+                                {{ radio.tag }}
+                                <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.turbidity.label }}</td>
+                        {% endif %}
+
+                        <td>
+                            <div class="input-field">{{ sample.turbidity }}</div>
+                            {{ sample.turbid_tool.errors | striptags }}
+
+                            {% for radio in sample.turbid_tool %}
+                                {{ radio.tag }}
+                                <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.salinity.label }}</td>
+                        {% endif %}
+
+                        <td>
+                            <div class="input-field">{{ sample.salinity }}</div>
+                            {{ sample.salt_tool.errors | striptags }}
+
+                            {% for radio in sample.salt_tool %}
+                                {{ radio.tag }}
+                                <label for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+
+                <tr class="collapse-btn">
+                    <th>Additional parameters <i class="material-icons">arrow_drop_down</i></th>
+                </tr>
+            </tbody>
+        </table>
+
+        <div class="collapse">
+            <table>
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.conductivity.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.conductivity }}</div></td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.total_solids.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.total_solids }}</div></td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.bod.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.bod }}</div></td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.ammonia.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.ammonia }}</div></td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.nitrite.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.nitrite }}</div></td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.phosphates.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.phosphates }}</div></td>
+                    {% endfor %}
+                </tr>
+
+                <tr>
+                    {% for sample in sample_formset %}
+                        {% if forloop.first %}
+                            <td>{{ sample.fecal_coliform.label }}</td>
+                        {% endif %}
+
+                        <td><div class="input-field">{{ sample.fecal_coliform }}</div></td>
+                    {% endfor %}
+                </tr>
+            </table>
+        </div>
+
+        <div class="input-field">
+            <label for="{{ wq_form.notes.id_for_label }}">{{ wq_form.notes.label }}</label>
+            {{ wq_form.notes.errors | striptags }}
+            {{ wq_form.notes }}
+        </div>
+
+        {% if editable %}
+            <input class="btn waves-effect waves-light teal darken-4" type="submit" value="Submit">
+        {% endif %}
+    </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
The @login_required decorator in views.py means that if the user isn't logged in, it automatically redirects to the login page, so these checks are unnecessary.

<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #232.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Remove ``{% if user.is_authenticated %}`` checks from all the edit data templates.

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. ``docker-compose up``
2. Add data to a site via the various edit views.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

All of the pages should still correctly display and add data as before, or redirect to the login page if not logged in.

@osuosl/devs