### PR TITLE
Fix canopy cover responsiveness

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -74,6 +74,8 @@
         <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
         <form id='canopy_cover_form' method='post'>
         {% csrf_token %}
+            {{ canopy_cover_form.non_field_errors }}
+
             <div class="row">
                 <div class="col s12">
                     <div class="input-field">
@@ -103,6 +105,34 @@
                         {{ canopy_cover_form.weather }}
                     </div>
                 </div>
+            </div>
+
+            <div class="row" style="display: none;">
+                {{ canopy_cover_form.north_cc.label }}
+
+                {{ canopy_cover_form.north_cc.errors | striptags }}
+                <span id='north-form'>{{ canopy_cover_form.north_cc }}</span>
+            </div>
+
+            <div class="row" style="display: none;">
+                {{ canopy_cover_form.east_cc.label }}
+
+                {{ canopy_cover_form.east_cc.errors | striptags }}
+                <span id='east-form'>{{ canopy_cover_form.east_cc }}</span>
+            </div>
+
+            <div class="row" style="display: none;">
+                {{ canopy_cover_form.west_cc.label }}
+
+                {{ canopy_cover_form.west_cc.errors | striptags }}
+                <span id='west-form'>{{ canopy_cover_form.west_cc }}</span>
+            </div>
+
+            <div class="row" style="display: none;">
+                {{ canopy_cover_form.south_cc.label }}
+
+                {{ canopy_cover_form.south_cc.errors | striptags }}
+                <span id='south-form'>{{ canopy_cover_form.south_cc }}</span>
             </div>
 
             <div id="canopies">

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -15,20 +15,24 @@
     }
 
     .canopy {
-        color: #000000;
-        width: 300px;
+        color: #000;
+        width: 350px;
         height: 350px;
+        min-width: 350px;
+        max-width: 350px;
         display: inline-block;
-        margin-left: 30px;
-        margin-right: 30px;
+    }
+
+    #canopies > .row {
+        text-align: center;
     }
 
     .canopy-square {
+        display: inline-block;
         width: 50px;
         height: 50px;
-        border: solid black 1px;
-        float: left;
-        margin: -1px -1px 0 0;
+        outline: 1px solid;
+        margin-top: 1px;
 
         text-align: center;
         line-height: 50px;
@@ -85,194 +89,193 @@
                 </div>
             </div>
 
+            <div id="canopies">
+                <div class="row">
+                    <div id="canopy-north" class="canopy">
+                        <p class="header">North</p>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-0-0">A</div>
+                        <div class="canopy-square shown" id="square-0-1">B</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-0-2">C</div>
+                        <div class="canopy-square shown" id="square-0-3">D</div>
+                        <div class="canopy-square shown" id="square-0-4">E</div>
+                        <div class="canopy-square shown" id="square-0-5">F</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square shown" id="square-0-6">G</div>
+                        <div class="canopy-square shown" id="square-0-7">H</div>
+                        <div class="canopy-square shown" id="square-0-8">I</div>
+                        <div class="canopy-square shown" id="square-0-9">J</div>
+                        <div class="canopy-square shown" id="square-0-10">K</div>
+                        <div class="canopy-square shown" id="square-0-11">L</div>
+
+                        <div class="canopy-square shown" id="square-0-12">M</div>
+                        <div class="canopy-square shown" id="square-0-13">N</div>
+                        <div class="canopy-square shown" id="square-0-14">O</div>
+                        <div class="canopy-square shown" id="square-0-15">P</div>
+                        <div class="canopy-square shown" id="square-0-16">Q</div>
+                        <div class="canopy-square shown" id="square-0-17">R</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-0-18">S</div>
+                        <div class="canopy-square shown" id="square-0-19">T</div>
+                        <div class="canopy-square shown" id="square-0-20">U</div>
+                        <div class="canopy-square shown" id="square-0-21">V</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-0-22">W</div>
+                        <div class="canopy-square shown" id="square-0-23">X</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                    </div>
+
+                    <div id="canopy-west" class="canopy">
+                        <p class="header">West</p>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-1-0">A</div>
+                        <div class="canopy-square shown" id="square-1-1">B</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-1-2">C</div>
+                        <div class="canopy-square shown" id="square-1-3">D</div>
+                        <div class="canopy-square shown" id="square-1-4">E</div>
+                        <div class="canopy-square shown" id="square-1-5">F</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square shown" id="square-1-6">G</div>
+                        <div class="canopy-square shown" id="square-1-7">H</div>
+                        <div class="canopy-square shown" id="square-1-8">I</div>
+                        <div class="canopy-square shown" id="square-1-9">J</div>
+                        <div class="canopy-square shown" id="square-1-10">K</div>
+                        <div class="canopy-square shown" id="square-1-11">L</div>
+
+                        <div class="canopy-square shown" id="square-1-12">M</div>
+                        <div class="canopy-square shown" id="square-1-13">N</div>
+                        <div class="canopy-square shown" id="square-1-14">O</div>
+                        <div class="canopy-square shown" id="square-1-15">P</div>
+                        <div class="canopy-square shown" id="square-1-16">Q</div>
+                        <div class="canopy-square shown" id="square-1-17">R</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-1-18">S</div>
+                        <div class="canopy-square shown" id="square-1-19">T</div>
+                        <div class="canopy-square shown" id="square-1-20">U</div>
+                        <div class="canopy-square shown" id="square-1-21">V</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-1-22">W</div>
+                        <div class="canopy-square shown" id="square-1-23">X</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div id="canopy-east" class="canopy">
+                        <p class="header">East</p>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-2-0">A</div>
+                        <div class="canopy-square shown" id="square-2-1">B</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-2-2">C</div>
+                        <div class="canopy-square shown" id="square-2-3">D</div>
+                        <div class="canopy-square shown" id="square-2-4">E</div>
+                        <div class="canopy-square shown" id="square-2-5">F</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square shown" id="square-2-6">G</div>
+                        <div class="canopy-square shown" id="square-2-7">H</div>
+                        <div class="canopy-square shown" id="square-2-8">I</div>
+                        <div class="canopy-square shown" id="square-2-9">J</div>
+                        <div class="canopy-square shown" id="square-2-10">K</div>
+                        <div class="canopy-square shown" id="square-2-11">L</div>
+
+                        <div class="canopy-square shown" id="square-2-12">M</div>
+                        <div class="canopy-square shown" id="square-2-13">N</div>
+                        <div class="canopy-square shown" id="square-2-14">O</div>
+                        <div class="canopy-square shown" id="square-2-15">P</div>
+                        <div class="canopy-square shown" id="square-2-16">Q</div>
+                        <div class="canopy-square shown" id="square-2-17">R</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-2-18">S</div>
+                        <div class="canopy-square shown" id="square-2-19">T</div>
+                        <div class="canopy-square shown" id="square-2-20">U</div>
+                        <div class="canopy-square shown" id="square-2-21">V</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-2-22">W</div>
+                        <div class="canopy-square shown" id="square-2-23">X</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                    </div>
+
+                    <div id="canopy-south" class="canopy">
+                        <p class="header">South</p>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-3-0">A</div>
+                        <div class="canopy-square shown" id="square-3-1">B</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-3-2">C</div>
+                        <div class="canopy-square shown" id="square-3-3">D</div>
+                        <div class="canopy-square shown" id="square-3-4">E</div>
+                        <div class="canopy-square shown" id="square-3-5">F</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square shown" id="square-3-6">G</div>
+                        <div class="canopy-square shown" id="square-3-7">H</div>
+                        <div class="canopy-square shown" id="square-3-8">I</div>
+                        <div class="canopy-square shown" id="square-3-9">J</div>
+                        <div class="canopy-square shown" id="square-3-10">K</div>
+                        <div class="canopy-square shown" id="square-3-11">L</div>
+
+                        <div class="canopy-square shown" id="square-3-12">M</div>
+                        <div class="canopy-square shown" id="square-3-13">N</div>
+                        <div class="canopy-square shown" id="square-3-14">O</div>
+                        <div class="canopy-square shown" id="square-3-15">P</div>
+                        <div class="canopy-square shown" id="square-3-16">Q</div>
+                        <div class="canopy-square shown" id="square-3-17">R</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-3-18">S</div>
+                        <div class="canopy-square shown" id="square-3-19">T</div>
+                        <div class="canopy-square shown" id="square-3-20">U</div>
+                        <div class="canopy-square shown" id="square-3-21">V</div>
+                        <div class="canopy-square hidden">Z</div>
+
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square shown" id="square-3-22">W</div>
+                        <div class="canopy-square shown" id="square-3-23">X</div>
+                        <div class="canopy-square hidden">Z</div>
+                        <div class="canopy-square hidden">Z</div>
+                    </div>
+                </div>
+            </div>
+
             <table>
-                <tr>
-                    <td>
-                        <div id="canopies">
-                            <div id="canopy-north" class="canopy">
-                                <p class="header">North</p>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-0-0">A</div>
-                                <div class="canopy-square shown" id="square-0-1">B</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-0-2">C</div>
-                                <div class="canopy-square shown" id="square-0-3">D</div>
-                                <div class="canopy-square shown" id="square-0-4">E</div>
-                                <div class="canopy-square shown" id="square-0-5">F</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square shown" id="square-0-6">G</div>
-                                <div class="canopy-square shown" id="square-0-7">H</div>
-                                <div class="canopy-square shown" id="square-0-8">I</div>
-                                <div class="canopy-square shown" id="square-0-9">J</div>
-                                <div class="canopy-square shown" id="square-0-10">K</div>
-                                <div class="canopy-square shown" id="square-0-11">L</div>
-
-                                <div class="canopy-square shown" id="square-0-12">M</div>
-                                <div class="canopy-square shown" id="square-0-13">N</div>
-                                <div class="canopy-square shown" id="square-0-14">O</div>
-                                <div class="canopy-square shown" id="square-0-15">P</div>
-                                <div class="canopy-square shown" id="square-0-16">Q</div>
-                                <div class="canopy-square shown" id="square-0-17">R</div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-0-18">S</div>
-                                <div class="canopy-square shown" id="square-0-19">T</div>
-                                <div class="canopy-square shown" id="square-0-20">U</div>
-                                <div class="canopy-square shown" id="square-0-21">V</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-0-22">W</div>
-                                <div class="canopy-square shown" id="square-0-23">X</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                            </div>
-
-                            <div id="canopy-west" class="canopy">
-                                <p class="header">West</p>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-1-0">A</div>
-                                <div class="canopy-square shown" id="square-1-1">B</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-1-2">C</div>
-                                <div class="canopy-square shown" id="square-1-3">D</div>
-                                <div class="canopy-square shown" id="square-1-4">E</div>
-                                <div class="canopy-square shown" id="square-1-5">F</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square shown" id="square-1-6">G</div>
-                                <div class="canopy-square shown" id="square-1-7">H</div>
-                                <div class="canopy-square shown" id="square-1-8">I</div>
-                                <div class="canopy-square shown" id="square-1-9">J</div>
-                                <div class="canopy-square shown" id="square-1-10">K</div>
-                                <div class="canopy-square shown" id="square-1-11">L</div>
-
-                                <div class="canopy-square shown" id="square-1-12">M</div>
-                                <div class="canopy-square shown" id="square-1-13">N</div>
-                                <div class="canopy-square shown" id="square-1-14">O</div>
-                                <div class="canopy-square shown" id="square-1-15">P</div>
-                                <div class="canopy-square shown" id="square-1-16">Q</div>
-                                <div class="canopy-square shown" id="square-1-17">R</div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-1-18">S</div>
-                                <div class="canopy-square shown" id="square-1-19">T</div>
-                                <div class="canopy-square shown" id="square-1-20">U</div>
-                                <div class="canopy-square shown" id="square-1-21">V</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-1-22">W</div>
-                                <div class="canopy-square shown" id="square-1-23">X</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                            </div>
-
-                            <div id="canopy-east" class="canopy">
-                                <p class="header">East</p>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-2-0">A</div>
-                                <div class="canopy-square shown" id="square-2-1">B</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-2-2">C</div>
-                                <div class="canopy-square shown" id="square-2-3">D</div>
-                                <div class="canopy-square shown" id="square-2-4">E</div>
-                                <div class="canopy-square shown" id="square-2-5">F</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square shown" id="square-2-6">G</div>
-                                <div class="canopy-square shown" id="square-2-7">H</div>
-                                <div class="canopy-square shown" id="square-2-8">I</div>
-                                <div class="canopy-square shown" id="square-2-9">J</div>
-                                <div class="canopy-square shown" id="square-2-10">K</div>
-                                <div class="canopy-square shown" id="square-2-11">L</div>
-
-                                <div class="canopy-square shown" id="square-2-12">M</div>
-                                <div class="canopy-square shown" id="square-2-13">N</div>
-                                <div class="canopy-square shown" id="square-2-14">O</div>
-                                <div class="canopy-square shown" id="square-2-15">P</div>
-                                <div class="canopy-square shown" id="square-2-16">Q</div>
-                                <div class="canopy-square shown" id="square-2-17">R</div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-2-18">S</div>
-                                <div class="canopy-square shown" id="square-2-19">T</div>
-                                <div class="canopy-square shown" id="square-2-20">U</div>
-                                <div class="canopy-square shown" id="square-2-21">V</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-2-22">W</div>
-                                <div class="canopy-square shown" id="square-2-23">X</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                            </div>
-
-                            <div id="canopy-south" class="canopy">
-                                <p class="header">South</p>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-3-0">A</div>
-                                <div class="canopy-square shown" id="square-3-1">B</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-3-2">C</div>
-                                <div class="canopy-square shown" id="square-3-3">D</div>
-                                <div class="canopy-square shown" id="square-3-4">E</div>
-                                <div class="canopy-square shown" id="square-3-5">F</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square shown" id="square-3-6">G</div>
-                                <div class="canopy-square shown" id="square-3-7">H</div>
-                                <div class="canopy-square shown" id="square-3-8">I</div>
-                                <div class="canopy-square shown" id="square-3-9">J</div>
-                                <div class="canopy-square shown" id="square-3-10">K</div>
-                                <div class="canopy-square shown" id="square-3-11">L</div>
-
-                                <div class="canopy-square shown" id="square-3-12">M</div>
-                                <div class="canopy-square shown" id="square-3-13">N</div>
-                                <div class="canopy-square shown" id="square-3-14">O</div>
-                                <div class="canopy-square shown" id="square-3-15">P</div>
-                                <div class="canopy-square shown" id="square-3-16">Q</div>
-                                <div class="canopy-square shown" id="square-3-17">R</div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-3-18">S</div>
-                                <div class="canopy-square shown" id="square-3-19">T</div>
-                                <div class="canopy-square shown" id="square-3-20">U</div>
-                                <div class="canopy-square shown" id="square-3-21">V</div>
-                                <div class="canopy-square hidden"></div>
-
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square shown" id="square-3-22">W</div>
-                                <div class="canopy-square shown" id="square-3-23">X</div>
-                                <div class="canopy-square hidden"></div>
-                                <div class="canopy-square hidden"></div>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-
-                <tr></tr>
                 <tr>
                     <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
                     <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -55,7 +55,6 @@
     }
 </style>
 
-<<<<<<< HEAD
 {% if added %}
     <strong>{% trans "You have successfully submitted your Canopy Cover Survey." %}</strong>
 {% else %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -59,273 +59,271 @@
 {% if added %}
     <strong>{% trans "You have successfully submitted your Canopy Cover Survey." %}</strong>
 {% else %}
-    <div class="container">
-        <h3 align="center">
-            <a href="{% url 'streamwebs:site' site.site_slug %}">
-                {{ site.site_name }}
-            </a>
-        </h3>
-        <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
-        <form id='canopy_cover_form' method='post'>
-        {% csrf_token %}
-            {{ canopy_cover_form.non_field_errors }}
+    <h3 align="center">
+        <a href="{% url 'streamwebs:site' site.site_slug %}">
+            {{ site.site_name }}
+        </a>
+    </h3>
+    <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
+    <form id='canopy_cover_form' method='post'>
+    {% csrf_token %}
+        {{ canopy_cover_form.non_field_errors }}
+
+        <div class="row">
+            <div class="col s12">
+                <div class="input-field">
+                    {{ canopy_cover_form.school.label }}
+
+                    {{ canopy_cover_form.school.errors | striptags }}
+                    {{ canopy_cover_form.school }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col s6">
+                <div class="input-field">
+                    {{ canopy_cover_form.date_time.label }}
+
+                    {{ canopy_cover_form.date_time.errors | striptags }}
+                    {{ canopy_cover_form.date_time }}
+                </div>
+            </div>
+
+            <div class="col s6">
+                <div class="input-field">
+                    {{ canopy_cover_form.weather.label }}
+
+                    {{ canopy_cover_form.weather.errors | striptags }}
+                    {{ canopy_cover_form.weather }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row" style="display: none;">
+            {{ canopy_cover_form.north_cc.label }}
+
+            {{ canopy_cover_form.north_cc.errors | striptags }}
+            <span id='north-form'>{{ canopy_cover_form.north_cc }}</span>
+        </div>
+
+        <div class="row" style="display: none;">
+            {{ canopy_cover_form.east_cc.label }}
+
+            {{ canopy_cover_form.east_cc.errors | striptags }}
+            <span id='east-form'>{{ canopy_cover_form.east_cc }}</span>
+        </div>
+
+        <div class="row" style="display: none;">
+            {{ canopy_cover_form.west_cc.label }}
+
+            {{ canopy_cover_form.west_cc.errors | striptags }}
+            <span id='west-form'>{{ canopy_cover_form.west_cc }}</span>
+        </div>
+
+        <div class="row" style="display: none;">
+            {{ canopy_cover_form.south_cc.label }}
+
+            {{ canopy_cover_form.south_cc.errors | striptags }}
+            <span id='south-form'>{{ canopy_cover_form.south_cc }}</span>
+        </div>
+
+        <div id="canopies">
+            <div class="row">
+                <div id="canopy-north" class="canopy">
+                    <p class="header">North</p>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-0-0">A</div>
+                    <div class="canopy-square shown" id="square-0-1">B</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-0-2">C</div>
+                    <div class="canopy-square shown" id="square-0-3">D</div>
+                    <div class="canopy-square shown" id="square-0-4">E</div>
+                    <div class="canopy-square shown" id="square-0-5">F</div>
+                    <div class="canopy-square hidden">Z</div>
+
+                    <div class="canopy-square shown" id="square-0-6">G</div>
+                    <div class="canopy-square shown" id="square-0-7">H</div>
+                    <div class="canopy-square shown" id="square-0-8">I</div>
+                    <div class="canopy-square shown" id="square-0-9">J</div>
+                    <div class="canopy-square shown" id="square-0-10">K</div>
+                    <div class="canopy-square shown" id="square-0-11">L</div>
+
+                    <div class="canopy-square shown" id="square-0-12">M</div>
+                    <div class="canopy-square shown" id="square-0-13">N</div>
+                    <div class="canopy-square shown" id="square-0-14">O</div>
+                    <div class="canopy-square shown" id="square-0-15">P</div>
+                    <div class="canopy-square shown" id="square-0-16">Q</div>
+                    <div class="canopy-square shown" id="square-0-17">R</div>
+
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-0-18">S</div>
+                    <div class="canopy-square shown" id="square-0-19">T</div>
+                    <div class="canopy-square shown" id="square-0-20">U</div>
+                    <div class="canopy-square shown" id="square-0-21">V</div>
+                    <div class="canopy-square hidden">Z</div>
+
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-0-22">W</div>
+                    <div class="canopy-square shown" id="square-0-23">X</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                </div>
+
+                <div id="canopy-west" class="canopy">
+                    <p class="header">West</p>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-1-0">A</div>
+                    <div class="canopy-square shown" id="square-1-1">B</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-1-2">C</div>
+                    <div class="canopy-square shown" id="square-1-3">D</div>
+                    <div class="canopy-square shown" id="square-1-4">E</div>
+                    <div class="canopy-square shown" id="square-1-5">F</div>
+                    <div class="canopy-square hidden">Z</div>
+
+                    <div class="canopy-square shown" id="square-1-6">G</div>
+                    <div class="canopy-square shown" id="square-1-7">H</div>
+                    <div class="canopy-square shown" id="square-1-8">I</div>
+                    <div class="canopy-square shown" id="square-1-9">J</div>
+                    <div class="canopy-square shown" id="square-1-10">K</div>
+                    <div class="canopy-square shown" id="square-1-11">L</div>
+
+                    <div class="canopy-square shown" id="square-1-12">M</div>
+                    <div class="canopy-square shown" id="square-1-13">N</div>
+                    <div class="canopy-square shown" id="square-1-14">O</div>
+                    <div class="canopy-square shown" id="square-1-15">P</div>
+                    <div class="canopy-square shown" id="square-1-16">Q</div>
+                    <div class="canopy-square shown" id="square-1-17">R</div>
+
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-1-18">S</div>
+                    <div class="canopy-square shown" id="square-1-19">T</div>
+                    <div class="canopy-square shown" id="square-1-20">U</div>
+                    <div class="canopy-square shown" id="square-1-21">V</div>
+                    <div class="canopy-square hidden">Z</div>
+
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-1-22">W</div>
+                    <div class="canopy-square shown" id="square-1-23">X</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                </div>
+            </div>
 
             <div class="row">
-                <div class="col s12">
-                    <div class="input-field">
-                        {{ canopy_cover_form.school.label }}
+                <div id="canopy-east" class="canopy">
+                    <p class="header">East</p>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-2-0">A</div>
+                    <div class="canopy-square shown" id="square-2-1">B</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
 
-                        {{ canopy_cover_form.school.errors | striptags }}
-                        {{ canopy_cover_form.school }}
-                    </div>
-                </div>
-            </div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-2-2">C</div>
+                    <div class="canopy-square shown" id="square-2-3">D</div>
+                    <div class="canopy-square shown" id="square-2-4">E</div>
+                    <div class="canopy-square shown" id="square-2-5">F</div>
+                    <div class="canopy-square hidden">Z</div>
 
-            <div class="row">
-                <div class="col s6">
-                    <div class="input-field">
-                        {{ canopy_cover_form.date_time.label }}
+                    <div class="canopy-square shown" id="square-2-6">G</div>
+                    <div class="canopy-square shown" id="square-2-7">H</div>
+                    <div class="canopy-square shown" id="square-2-8">I</div>
+                    <div class="canopy-square shown" id="square-2-9">J</div>
+                    <div class="canopy-square shown" id="square-2-10">K</div>
+                    <div class="canopy-square shown" id="square-2-11">L</div>
 
-                        {{ canopy_cover_form.date_time.errors | striptags }}
-                        {{ canopy_cover_form.date_time }}
-                    </div>
-                </div>
+                    <div class="canopy-square shown" id="square-2-12">M</div>
+                    <div class="canopy-square shown" id="square-2-13">N</div>
+                    <div class="canopy-square shown" id="square-2-14">O</div>
+                    <div class="canopy-square shown" id="square-2-15">P</div>
+                    <div class="canopy-square shown" id="square-2-16">Q</div>
+                    <div class="canopy-square shown" id="square-2-17">R</div>
 
-                <div class="col s6">
-                    <div class="input-field">
-                        {{ canopy_cover_form.weather.label }}
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-2-18">S</div>
+                    <div class="canopy-square shown" id="square-2-19">T</div>
+                    <div class="canopy-square shown" id="square-2-20">U</div>
+                    <div class="canopy-square shown" id="square-2-21">V</div>
+                    <div class="canopy-square hidden">Z</div>
 
-                        {{ canopy_cover_form.weather.errors | striptags }}
-                        {{ canopy_cover_form.weather }}
-                    </div>
-                </div>
-            </div>
-
-            <div class="row" style="display: none;">
-                {{ canopy_cover_form.north_cc.label }}
-
-                {{ canopy_cover_form.north_cc.errors | striptags }}
-                <span id='north-form'>{{ canopy_cover_form.north_cc }}</span>
-            </div>
-
-            <div class="row" style="display: none;">
-                {{ canopy_cover_form.east_cc.label }}
-
-                {{ canopy_cover_form.east_cc.errors | striptags }}
-                <span id='east-form'>{{ canopy_cover_form.east_cc }}</span>
-            </div>
-
-            <div class="row" style="display: none;">
-                {{ canopy_cover_form.west_cc.label }}
-
-                {{ canopy_cover_form.west_cc.errors | striptags }}
-                <span id='west-form'>{{ canopy_cover_form.west_cc }}</span>
-            </div>
-
-            <div class="row" style="display: none;">
-                {{ canopy_cover_form.south_cc.label }}
-
-                {{ canopy_cover_form.south_cc.errors | striptags }}
-                <span id='south-form'>{{ canopy_cover_form.south_cc }}</span>
-            </div>
-
-            <div id="canopies">
-                <div class="row">
-                    <div id="canopy-north" class="canopy">
-                        <p class="header">North</p>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-0-0">A</div>
-                        <div class="canopy-square shown" id="square-0-1">B</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-0-2">C</div>
-                        <div class="canopy-square shown" id="square-0-3">D</div>
-                        <div class="canopy-square shown" id="square-0-4">E</div>
-                        <div class="canopy-square shown" id="square-0-5">F</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square shown" id="square-0-6">G</div>
-                        <div class="canopy-square shown" id="square-0-7">H</div>
-                        <div class="canopy-square shown" id="square-0-8">I</div>
-                        <div class="canopy-square shown" id="square-0-9">J</div>
-                        <div class="canopy-square shown" id="square-0-10">K</div>
-                        <div class="canopy-square shown" id="square-0-11">L</div>
-
-                        <div class="canopy-square shown" id="square-0-12">M</div>
-                        <div class="canopy-square shown" id="square-0-13">N</div>
-                        <div class="canopy-square shown" id="square-0-14">O</div>
-                        <div class="canopy-square shown" id="square-0-15">P</div>
-                        <div class="canopy-square shown" id="square-0-16">Q</div>
-                        <div class="canopy-square shown" id="square-0-17">R</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-0-18">S</div>
-                        <div class="canopy-square shown" id="square-0-19">T</div>
-                        <div class="canopy-square shown" id="square-0-20">U</div>
-                        <div class="canopy-square shown" id="square-0-21">V</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-0-22">W</div>
-                        <div class="canopy-square shown" id="square-0-23">X</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                    </div>
-
-                    <div id="canopy-west" class="canopy">
-                        <p class="header">West</p>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-1-0">A</div>
-                        <div class="canopy-square shown" id="square-1-1">B</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-1-2">C</div>
-                        <div class="canopy-square shown" id="square-1-3">D</div>
-                        <div class="canopy-square shown" id="square-1-4">E</div>
-                        <div class="canopy-square shown" id="square-1-5">F</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square shown" id="square-1-6">G</div>
-                        <div class="canopy-square shown" id="square-1-7">H</div>
-                        <div class="canopy-square shown" id="square-1-8">I</div>
-                        <div class="canopy-square shown" id="square-1-9">J</div>
-                        <div class="canopy-square shown" id="square-1-10">K</div>
-                        <div class="canopy-square shown" id="square-1-11">L</div>
-
-                        <div class="canopy-square shown" id="square-1-12">M</div>
-                        <div class="canopy-square shown" id="square-1-13">N</div>
-                        <div class="canopy-square shown" id="square-1-14">O</div>
-                        <div class="canopy-square shown" id="square-1-15">P</div>
-                        <div class="canopy-square shown" id="square-1-16">Q</div>
-                        <div class="canopy-square shown" id="square-1-17">R</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-1-18">S</div>
-                        <div class="canopy-square shown" id="square-1-19">T</div>
-                        <div class="canopy-square shown" id="square-1-20">U</div>
-                        <div class="canopy-square shown" id="square-1-21">V</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-1-22">W</div>
-                        <div class="canopy-square shown" id="square-1-23">X</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                    </div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-2-22">W</div>
+                    <div class="canopy-square shown" id="square-2-23">X</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
                 </div>
 
-                <div class="row">
-                    <div id="canopy-east" class="canopy">
-                        <p class="header">East</p>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-2-0">A</div>
-                        <div class="canopy-square shown" id="square-2-1">B</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
+                <div id="canopy-south" class="canopy">
+                    <p class="header">South</p>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-3-0">A</div>
+                    <div class="canopy-square shown" id="square-3-1">B</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
 
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-2-2">C</div>
-                        <div class="canopy-square shown" id="square-2-3">D</div>
-                        <div class="canopy-square shown" id="square-2-4">E</div>
-                        <div class="canopy-square shown" id="square-2-5">F</div>
-                        <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-3-2">C</div>
+                    <div class="canopy-square shown" id="square-3-3">D</div>
+                    <div class="canopy-square shown" id="square-3-4">E</div>
+                    <div class="canopy-square shown" id="square-3-5">F</div>
+                    <div class="canopy-square hidden">Z</div>
 
-                        <div class="canopy-square shown" id="square-2-6">G</div>
-                        <div class="canopy-square shown" id="square-2-7">H</div>
-                        <div class="canopy-square shown" id="square-2-8">I</div>
-                        <div class="canopy-square shown" id="square-2-9">J</div>
-                        <div class="canopy-square shown" id="square-2-10">K</div>
-                        <div class="canopy-square shown" id="square-2-11">L</div>
+                    <div class="canopy-square shown" id="square-3-6">G</div>
+                    <div class="canopy-square shown" id="square-3-7">H</div>
+                    <div class="canopy-square shown" id="square-3-8">I</div>
+                    <div class="canopy-square shown" id="square-3-9">J</div>
+                    <div class="canopy-square shown" id="square-3-10">K</div>
+                    <div class="canopy-square shown" id="square-3-11">L</div>
 
-                        <div class="canopy-square shown" id="square-2-12">M</div>
-                        <div class="canopy-square shown" id="square-2-13">N</div>
-                        <div class="canopy-square shown" id="square-2-14">O</div>
-                        <div class="canopy-square shown" id="square-2-15">P</div>
-                        <div class="canopy-square shown" id="square-2-16">Q</div>
-                        <div class="canopy-square shown" id="square-2-17">R</div>
+                    <div class="canopy-square shown" id="square-3-12">M</div>
+                    <div class="canopy-square shown" id="square-3-13">N</div>
+                    <div class="canopy-square shown" id="square-3-14">O</div>
+                    <div class="canopy-square shown" id="square-3-15">P</div>
+                    <div class="canopy-square shown" id="square-3-16">Q</div>
+                    <div class="canopy-square shown" id="square-3-17">R</div>
 
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-2-18">S</div>
-                        <div class="canopy-square shown" id="square-2-19">T</div>
-                        <div class="canopy-square shown" id="square-2-20">U</div>
-                        <div class="canopy-square shown" id="square-2-21">V</div>
-                        <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-3-18">S</div>
+                    <div class="canopy-square shown" id="square-3-19">T</div>
+                    <div class="canopy-square shown" id="square-3-20">U</div>
+                    <div class="canopy-square shown" id="square-3-21">V</div>
+                    <div class="canopy-square hidden">Z</div>
 
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-2-22">W</div>
-                        <div class="canopy-square shown" id="square-2-23">X</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                    </div>
-
-                    <div id="canopy-south" class="canopy">
-                        <p class="header">South</p>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-3-0">A</div>
-                        <div class="canopy-square shown" id="square-3-1">B</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-3-2">C</div>
-                        <div class="canopy-square shown" id="square-3-3">D</div>
-                        <div class="canopy-square shown" id="square-3-4">E</div>
-                        <div class="canopy-square shown" id="square-3-5">F</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square shown" id="square-3-6">G</div>
-                        <div class="canopy-square shown" id="square-3-7">H</div>
-                        <div class="canopy-square shown" id="square-3-8">I</div>
-                        <div class="canopy-square shown" id="square-3-9">J</div>
-                        <div class="canopy-square shown" id="square-3-10">K</div>
-                        <div class="canopy-square shown" id="square-3-11">L</div>
-
-                        <div class="canopy-square shown" id="square-3-12">M</div>
-                        <div class="canopy-square shown" id="square-3-13">N</div>
-                        <div class="canopy-square shown" id="square-3-14">O</div>
-                        <div class="canopy-square shown" id="square-3-15">P</div>
-                        <div class="canopy-square shown" id="square-3-16">Q</div>
-                        <div class="canopy-square shown" id="square-3-17">R</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-3-18">S</div>
-                        <div class="canopy-square shown" id="square-3-19">T</div>
-                        <div class="canopy-square shown" id="square-3-20">U</div>
-                        <div class="canopy-square shown" id="square-3-21">V</div>
-                        <div class="canopy-square hidden">Z</div>
-
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square shown" id="square-3-22">W</div>
-                        <div class="canopy-square shown" id="square-3-23">X</div>
-                        <div class="canopy-square hidden">Z</div>
-                        <div class="canopy-square hidden">Z</div>
-                    </div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square shown" id="square-3-22">W</div>
+                    <div class="canopy-square shown" id="square-3-23">X</div>
+                    <div class="canopy-square hidden">Z</div>
+                    <div class="canopy-square hidden">Z</div>
                 </div>
             </div>
+        </div>
 
-            <table>
-                <tr>
-                    <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
-                    <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>
-                    <td><span class="grey-text" id="percent">0%</span></td>
-                    <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
-                </tr>
-            </table> <!-- end canopy cover -->
-            <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit'/>
-        </form>
-    </div>
+        <table>
+            <tr>
+                <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
+                <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>
+                <td><span class="grey-text" id="percent">0%</span></td>
+                <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
+            </tr>
+        </table> <!-- end canopy cover -->
+        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit'/>
+    </form>
 {% endif %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -28,6 +28,7 @@
     }
 
     .canopy-square {
+        cursor: default;
         display: inline-block;
         width: 50px;
         height: 50px;

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -7,42 +7,20 @@
 
 {% block content %}
 <style>
-    #canopies {
-        cursor: default;
-    }
-
     p.header {
-        margin: 10px auto;
         text-align: center;
         font-weight: bold;
         line-height: 10px;
-    }
-
-    #canopy-north {
-        margin-left: 700px;
-        margin-bottom: -150px;
-    }
-
-    #canopy-west {
-        float: left;
-        margin-left: 475px;
-        margin-right: 150px;
-        margin-bottom: -150px;
-    }
-
-    #canopy-east {
-        float: left;
-        margin-bottom: -150px;
-    }
-
-    #canopy-south {
-        margin-left: 700px;
+        height: 10px;
     }
 
     .canopy {
+        color: #000000;
         width: 300px;
         height: 350px;
-        padding: 1px 1px 0 0;
+        display: inline-block;
+        margin-left: 30px;
+        margin-right: 30px;
     }
 
     .canopy-square {
@@ -56,7 +34,6 @@
         line-height: 50px;
         font-size: 2em;
         font-weight: bold;
-        pointer-events: all;
     }
 
     .canopy-square.hidden {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -41,252 +41,248 @@
     }
 </style>
 
+<<<<<<< HEAD
 {% if added %}
     <strong>{% trans "You have successfully submitted your Canopy Cover Survey." %}</strong>
-
 {% else %}
-<h3 align="center">
-    <a href="{% url 'streamwebs:site' site.site_slug %}">
-        {{ site.site_name }}
-    </a>
-</h3>
-<h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
-<form id='canopy_cover_form' method='post'>
-{% csrf_token %}
-    <table> <!-- main cc info table -->
-        <tr>{{ canopy_cover_form.non_field_errors }}</tr>
-        <tr>
-            <th align='left'>{{ canopy_cover_form.school.label }}</th>
-            <td>{{ canopy_cover_form.school }}</td>
-            <td>{{ canopy_cover_form.school.errors }}</td>
-        </tr>
-        <tr>
-            <th align='left'>{{ canopy_cover_form.date_time.label }}</th>
-            <td>{{ canopy_cover_form.date_time }}</td>
-            <td>{{ canopy_cover_form.date_time.errors }}</td>
-        </tr>
-        <tr>
-            <th align='left'>{{ canopy_cover_form.weather.label }}</th>
-            <td>{{ canopy_cover_form.weather }}</td>
-            <td>{{ canopy_cover_form.weather.errors }}</td>
-        </tr>
-        <tr style='display: none'>
-            <th align='left'>{{ canopy_cover_form.north_cc.label }}</th>
-            <td id='north-form'>{{ canopy_cover_form.north_cc }}</td>
-            <td>{{ canopy_cover_form.north_cc.errors }}</td>
-        </tr>
-        <tr style='display: none'>
-            <th align='left'>{{ canopy_cover_form.east_cc.label }}</th>
-            <td id='east-form'>{{ canopy_cover_form.east_cc }}</td>
-            <td>{{ canopy_cover_form.east_cc.errors }}</td>
-        </tr>
-        <tr style='display: none'>
-            <th align='left'>{{ canopy_cover_form.west_cc.label }}</th>
-            <td id='west-form'>{{ canopy_cover_form.west_cc }}</td>
-            <td>{{ canopy_cover_form.west_cc.errors }}</td>
-        </tr>
-        <tr style='display: none'>
-            <th align='left'>{{ canopy_cover_form.south_cc.label }}</th>
-            <td id='south-form'>{{ canopy_cover_form.south_cc }}</td>
-            <td>{{ canopy_cover_form.south_cc.errors }}</td>
-        </tr>
+    <div class="container">
+        <h3 align="center">
+            <a href="{% url 'streamwebs:site' site.site_slug %}">
+                {{ site.site_name }}
+            </a>
+        </h3>
+        <h4 align="center">{% trans 'New Canopy Cover Sampling' %}</h4>
+        <form id='canopy_cover_form' method='post'>
+        {% csrf_token %}
+            <div class="row">
+                <div class="col s12">
+                    <div class="input-field">
+                        {{ canopy_cover_form.school.label }}
 
-        <tr>
-            <td>
-                <div id="canopies">
-                    <div id="canopy-north" class="canopy">
-                        <p class="header">North</p>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-0-0">A</div>
-                        <div class="canopy-square shown" id="square-0-1">B</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-0-2">C</div>
-                        <div class="canopy-square shown" id="square-0-3">D</div>
-                        <div class="canopy-square shown" id="square-0-4">E</div>
-                        <div class="canopy-square shown" id="square-0-5">F</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square shown" id="square-0-6">G</div>
-                        <div class="canopy-square shown" id="square-0-7">H</div>
-                        <div class="canopy-square shown" id="square-0-8">I</div>
-                        <div class="canopy-square shown" id="square-0-9">J</div>
-                        <div class="canopy-square shown" id="square-0-10">K</div>
-                        <div class="canopy-square shown" id="square-0-11">L</div>
-
-                        <div class="canopy-square shown" id="square-0-12">M</div>
-                        <div class="canopy-square shown" id="square-0-13">N</div>
-                        <div class="canopy-square shown" id="square-0-14">O</div>
-                        <div class="canopy-square shown" id="square-0-15">P</div>
-                        <div class="canopy-square shown" id="square-0-16">Q</div>
-                        <div class="canopy-square shown" id="square-0-17">R</div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-0-18">S</div>
-                        <div class="canopy-square shown" id="square-0-19">T</div>
-                        <div class="canopy-square shown" id="square-0-20">U</div>
-                        <div class="canopy-square shown" id="square-0-21">V</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-0-22">W</div>
-                        <div class="canopy-square shown" id="square-0-23">X</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                    </div>
-
-                    <div id="canopy-west" class="canopy">
-                        <p class="header">West</p>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-1-0">A</div>
-                        <div class="canopy-square shown" id="square-1-1">B</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-1-2">C</div>
-                        <div class="canopy-square shown" id="square-1-3">D</div>
-                        <div class="canopy-square shown" id="square-1-4">E</div>
-                        <div class="canopy-square shown" id="square-1-5">F</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square shown" id="square-1-6">G</div>
-                        <div class="canopy-square shown" id="square-1-7">H</div>
-                        <div class="canopy-square shown" id="square-1-8">I</div>
-                        <div class="canopy-square shown" id="square-1-9">J</div>
-                        <div class="canopy-square shown" id="square-1-10">K</div>
-                        <div class="canopy-square shown" id="square-1-11">L</div>
-
-                        <div class="canopy-square shown" id="square-1-12">M</div>
-                        <div class="canopy-square shown" id="square-1-13">N</div>
-                        <div class="canopy-square shown" id="square-1-14">O</div>
-                        <div class="canopy-square shown" id="square-1-15">P</div>
-                        <div class="canopy-square shown" id="square-1-16">Q</div>
-                        <div class="canopy-square shown" id="square-1-17">R</div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-1-18">S</div>
-                        <div class="canopy-square shown" id="square-1-19">T</div>
-                        <div class="canopy-square shown" id="square-1-20">U</div>
-                        <div class="canopy-square shown" id="square-1-21">V</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-1-22">W</div>
-                        <div class="canopy-square shown" id="square-1-23">X</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                    </div>
-
-                    <div id="canopy-east" class="canopy">
-                        <p class="header">East</p>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-2-0">A</div>
-                        <div class="canopy-square shown" id="square-2-1">B</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-2-2">C</div>
-                        <div class="canopy-square shown" id="square-2-3">D</div>
-                        <div class="canopy-square shown" id="square-2-4">E</div>
-                        <div class="canopy-square shown" id="square-2-5">F</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square shown" id="square-2-6">G</div>
-                        <div class="canopy-square shown" id="square-2-7">H</div>
-                        <div class="canopy-square shown" id="square-2-8">I</div>
-                        <div class="canopy-square shown" id="square-2-9">J</div>
-                        <div class="canopy-square shown" id="square-2-10">K</div>
-                        <div class="canopy-square shown" id="square-2-11">L</div>
-
-                        <div class="canopy-square shown" id="square-2-12">M</div>
-                        <div class="canopy-square shown" id="square-2-13">N</div>
-                        <div class="canopy-square shown" id="square-2-14">O</div>
-                        <div class="canopy-square shown" id="square-2-15">P</div>
-                        <div class="canopy-square shown" id="square-2-16">Q</div>
-                        <div class="canopy-square shown" id="square-2-17">R</div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-2-18">S</div>
-                        <div class="canopy-square shown" id="square-2-19">T</div>
-                        <div class="canopy-square shown" id="square-2-20">U</div>
-                        <div class="canopy-square shown" id="square-2-21">V</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-2-22">W</div>
-                        <div class="canopy-square shown" id="square-2-23">X</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                    </div>
-
-                    <div id="canopy-south" class="canopy">
-                        <p class="header">South</p>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-3-0">A</div>
-                        <div class="canopy-square shown" id="square-3-1">B</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-3-2">C</div>
-                        <div class="canopy-square shown" id="square-3-3">D</div>
-                        <div class="canopy-square shown" id="square-3-4">E</div>
-                        <div class="canopy-square shown" id="square-3-5">F</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square shown" id="square-3-6">G</div>
-                        <div class="canopy-square shown" id="square-3-7">H</div>
-                        <div class="canopy-square shown" id="square-3-8">I</div>
-                        <div class="canopy-square shown" id="square-3-9">J</div>
-                        <div class="canopy-square shown" id="square-3-10">K</div>
-                        <div class="canopy-square shown" id="square-3-11">L</div>
-
-                        <div class="canopy-square shown" id="square-3-12">M</div>
-                        <div class="canopy-square shown" id="square-3-13">N</div>
-                        <div class="canopy-square shown" id="square-3-14">O</div>
-                        <div class="canopy-square shown" id="square-3-15">P</div>
-                        <div class="canopy-square shown" id="square-3-16">Q</div>
-                        <div class="canopy-square shown" id="square-3-17">R</div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-3-18">S</div>
-                        <div class="canopy-square shown" id="square-3-19">T</div>
-                        <div class="canopy-square shown" id="square-3-20">U</div>
-                        <div class="canopy-square shown" id="square-3-21">V</div>
-                        <div class="canopy-square hidden"></div>
-
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square shown" id="square-3-22">W</div>
-                        <div class="canopy-square shown" id="square-3-23">X</div>
-                        <div class="canopy-square hidden"></div>
-                        <div class="canopy-square hidden"></div>
+                        {{ canopy_cover_form.school.errors | striptags }}
+                        {{ canopy_cover_form.school }}
                     </div>
                 </div>
-            </td>
-        </tr>
+            </div>
 
-        <tr></tr>
-        <tr>
-            <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
-            <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>
-            <td><span class="grey-text" id="percent">0%</span></td>
-            <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
-        </tr>
-    </table> <!-- end canopy cover -->
-    <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit'/>
-</form>
+            <div class="row">
+                <div class="col s6">
+                    <div class="input-field">
+                        {{ canopy_cover_form.date_time.label }}
+
+                        {{ canopy_cover_form.date_time.errors | striptags }}
+                        {{ canopy_cover_form.date_time }}
+                    </div>
+                </div>
+
+                <div class="col s6">
+                    <div class="input-field">
+                        {{ canopy_cover_form.weather.label }}
+
+                        {{ canopy_cover_form.weather.errors | striptags }}
+                        {{ canopy_cover_form.weather }}
+                    </div>
+                </div>
+            </div>
+
+            <table>
+                <tr>
+                    <td>
+                        <div id="canopies">
+                            <div id="canopy-north" class="canopy">
+                                <p class="header">North</p>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-0-0">A</div>
+                                <div class="canopy-square shown" id="square-0-1">B</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-0-2">C</div>
+                                <div class="canopy-square shown" id="square-0-3">D</div>
+                                <div class="canopy-square shown" id="square-0-4">E</div>
+                                <div class="canopy-square shown" id="square-0-5">F</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square shown" id="square-0-6">G</div>
+                                <div class="canopy-square shown" id="square-0-7">H</div>
+                                <div class="canopy-square shown" id="square-0-8">I</div>
+                                <div class="canopy-square shown" id="square-0-9">J</div>
+                                <div class="canopy-square shown" id="square-0-10">K</div>
+                                <div class="canopy-square shown" id="square-0-11">L</div>
+
+                                <div class="canopy-square shown" id="square-0-12">M</div>
+                                <div class="canopy-square shown" id="square-0-13">N</div>
+                                <div class="canopy-square shown" id="square-0-14">O</div>
+                                <div class="canopy-square shown" id="square-0-15">P</div>
+                                <div class="canopy-square shown" id="square-0-16">Q</div>
+                                <div class="canopy-square shown" id="square-0-17">R</div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-0-18">S</div>
+                                <div class="canopy-square shown" id="square-0-19">T</div>
+                                <div class="canopy-square shown" id="square-0-20">U</div>
+                                <div class="canopy-square shown" id="square-0-21">V</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-0-22">W</div>
+                                <div class="canopy-square shown" id="square-0-23">X</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                            </div>
+
+                            <div id="canopy-west" class="canopy">
+                                <p class="header">West</p>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-1-0">A</div>
+                                <div class="canopy-square shown" id="square-1-1">B</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-1-2">C</div>
+                                <div class="canopy-square shown" id="square-1-3">D</div>
+                                <div class="canopy-square shown" id="square-1-4">E</div>
+                                <div class="canopy-square shown" id="square-1-5">F</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square shown" id="square-1-6">G</div>
+                                <div class="canopy-square shown" id="square-1-7">H</div>
+                                <div class="canopy-square shown" id="square-1-8">I</div>
+                                <div class="canopy-square shown" id="square-1-9">J</div>
+                                <div class="canopy-square shown" id="square-1-10">K</div>
+                                <div class="canopy-square shown" id="square-1-11">L</div>
+
+                                <div class="canopy-square shown" id="square-1-12">M</div>
+                                <div class="canopy-square shown" id="square-1-13">N</div>
+                                <div class="canopy-square shown" id="square-1-14">O</div>
+                                <div class="canopy-square shown" id="square-1-15">P</div>
+                                <div class="canopy-square shown" id="square-1-16">Q</div>
+                                <div class="canopy-square shown" id="square-1-17">R</div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-1-18">S</div>
+                                <div class="canopy-square shown" id="square-1-19">T</div>
+                                <div class="canopy-square shown" id="square-1-20">U</div>
+                                <div class="canopy-square shown" id="square-1-21">V</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-1-22">W</div>
+                                <div class="canopy-square shown" id="square-1-23">X</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                            </div>
+
+                            <div id="canopy-east" class="canopy">
+                                <p class="header">East</p>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-2-0">A</div>
+                                <div class="canopy-square shown" id="square-2-1">B</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-2-2">C</div>
+                                <div class="canopy-square shown" id="square-2-3">D</div>
+                                <div class="canopy-square shown" id="square-2-4">E</div>
+                                <div class="canopy-square shown" id="square-2-5">F</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square shown" id="square-2-6">G</div>
+                                <div class="canopy-square shown" id="square-2-7">H</div>
+                                <div class="canopy-square shown" id="square-2-8">I</div>
+                                <div class="canopy-square shown" id="square-2-9">J</div>
+                                <div class="canopy-square shown" id="square-2-10">K</div>
+                                <div class="canopy-square shown" id="square-2-11">L</div>
+
+                                <div class="canopy-square shown" id="square-2-12">M</div>
+                                <div class="canopy-square shown" id="square-2-13">N</div>
+                                <div class="canopy-square shown" id="square-2-14">O</div>
+                                <div class="canopy-square shown" id="square-2-15">P</div>
+                                <div class="canopy-square shown" id="square-2-16">Q</div>
+                                <div class="canopy-square shown" id="square-2-17">R</div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-2-18">S</div>
+                                <div class="canopy-square shown" id="square-2-19">T</div>
+                                <div class="canopy-square shown" id="square-2-20">U</div>
+                                <div class="canopy-square shown" id="square-2-21">V</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-2-22">W</div>
+                                <div class="canopy-square shown" id="square-2-23">X</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                            </div>
+
+                            <div id="canopy-south" class="canopy">
+                                <p class="header">South</p>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-3-0">A</div>
+                                <div class="canopy-square shown" id="square-3-1">B</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-3-2">C</div>
+                                <div class="canopy-square shown" id="square-3-3">D</div>
+                                <div class="canopy-square shown" id="square-3-4">E</div>
+                                <div class="canopy-square shown" id="square-3-5">F</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square shown" id="square-3-6">G</div>
+                                <div class="canopy-square shown" id="square-3-7">H</div>
+                                <div class="canopy-square shown" id="square-3-8">I</div>
+                                <div class="canopy-square shown" id="square-3-9">J</div>
+                                <div class="canopy-square shown" id="square-3-10">K</div>
+                                <div class="canopy-square shown" id="square-3-11">L</div>
+
+                                <div class="canopy-square shown" id="square-3-12">M</div>
+                                <div class="canopy-square shown" id="square-3-13">N</div>
+                                <div class="canopy-square shown" id="square-3-14">O</div>
+                                <div class="canopy-square shown" id="square-3-15">P</div>
+                                <div class="canopy-square shown" id="square-3-16">Q</div>
+                                <div class="canopy-square shown" id="square-3-17">R</div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-3-18">S</div>
+                                <div class="canopy-square shown" id="square-3-19">T</div>
+                                <div class="canopy-square shown" id="square-3-20">U</div>
+                                <div class="canopy-square shown" id="square-3-21">V</div>
+                                <div class="canopy-square hidden"></div>
+
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square shown" id="square-3-22">W</div>
+                                <div class="canopy-square shown" id="square-3-23">X</div>
+                                <div class="canopy-square hidden"></div>
+                                <div class="canopy-square hidden"></div>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr></tr>
+                <tr>
+                    <th align='left'>{{ canopy_cover_form.est_canopy_cover.label }}</th>
+                    <td style="display: none" id="total">{{ canopy_cover_form.est_canopy_cover }}</td>
+                    <td><span class="grey-text" id="percent">0%</span></td>
+                    <td>{{ canopy_cover_form.est_canopy_cover.errors }}</td>
+                </tr>
+            </table> <!-- end canopy cover -->
+            <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='Submit'/>
+        </form>
+    </div>
 {% endif %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -43,6 +43,19 @@
         margin-right: -3px;
     }
 
+    @media (max-width: 1370px) {
+        .canopy-square {
+            margin-right: -2px;
+        }
+
+        .canopy-square:nth-child(6n),
+        .canopy-square:nth-child(6n-1),
+        .canopy-square:nth-child(6n-3),
+        .canopy-square:nth-child(6n-4) {
+            margin-right: -3px !important;
+        }
+    }
+
     .canopy-square.hidden {
         visibility: hidden;
     }

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -44,16 +44,9 @@
         margin-right: -3px;
     }
 
-    @media (max-width: 1370px) {
+    @media (max-width: 991px) {
         .canopy-square {
             margin-right: -2px;
-        }
-
-        .canopy-square:nth-child(6n),
-        .canopy-square:nth-child(6n-1),
-        .canopy-square:nth-child(6n-3),
-        .canopy-square:nth-child(6n-4) {
-            margin-right: -3px !important;
         }
     }
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -32,12 +32,15 @@
         width: 50px;
         height: 50px;
         outline: 1px solid;
-        margin-top: 1px;
-
         text-align: center;
         line-height: 50px;
         font-size: 2em;
         font-weight: bold;
+
+        /* Don't remove - fixes weird spacing */
+        background-color: white;
+        margin-top: 1px;
+        margin-right: -3px;
     }
 
     .canopy-square.hidden {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -13,43 +13,20 @@
     </h3>
     <h4 align="center">Canopy Cover data: {{ canopy_cover.date_time|date:"m-d-Y" }}</h4>
 <style>
-    #canopies {
-        margin-left: 30%;
-        margin-top: -100px;
-        height: 710px;
-    }
-
     p.header {
         text-align: center;
         font-weight: bold;
         line-height: 10px;
-    }
-
-    #canopy-north {
-        margin-left: 225px;
-        margin-bottom: -150px;
-    }
-
-    #canopy-west {
-        float: left;
-        margin-right: 150px;
-        margin-bottom: -150px;
-    }
-
-    #canopy-east {
-        float: left;
-        margin-bottom: -150px;
-    }
-
-    #canopy-south {
-        margin-left: 225px;
+        height: 10px;
     }
 
     .canopy {
         color: #000000;
         width: 300px;
         height: 350px;
-        padding: 1px 1px 0 0;
+        display: inline-block;
+        margin-left: 30px;
+        margin-right: 30px;
     }
 
     .canopy-square {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -34,6 +34,7 @@
     }
 
     .canopy-square {
+        cursor: default;
         display: inline-block;
         width: 50px;
         height: 50px;

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -50,16 +50,9 @@
         margin-right: -3px;
     }
 
-    @media (max-width: 1370px) {
+    @media (max-width: 991px) {
         .canopy-square {
             margin-right: -2px;
-        }
-
-        .canopy-square:nth-child(6n),
-        .canopy-square:nth-child(6n-1),
-        .canopy-square:nth-child(6n-3),
-        .canopy-square:nth-child(6n-4) {
-            margin-right: -3px !important;
         }
     }
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -21,20 +21,24 @@
     }
 
     .canopy {
-        color: #000000;
-        width: 300px;
+        color: #000;
+        width: 350px;
         height: 350px;
+        min-width: 350px;
+        max-width: 350px;
         display: inline-block;
-        margin-left: 30px;
-        margin-right: 30px;
+    }
+
+    #canopies > .row {
+        text-align: center;
     }
 
     .canopy-square {
+        display: inline-block;
         width: 50px;
         height: 50px;
-        border: solid black 1px;
-        float: left;
-        margin: -1px -1px 0 0;
+        outline: 1px solid;
+        margin-top: 1px;
 
         text-align: center;
         line-height: 50px;
@@ -75,184 +79,189 @@
             let south_shades = {{ canopy_cover.south_cc }};
             let west_shades = {{ canopy_cover.west_cc }};
         </script>
-        <div id="canopy-north" class="canopy">
-            <p class="header">North</p>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-0-0">A</div>
-            <div class="canopy-square shown" id="square-0-1">B</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-0-2">C</div>
-            <div class="canopy-square shown" id="square-0-3">D</div>
-            <div class="canopy-square shown" id="square-0-4">E</div>
-            <div class="canopy-square shown" id="square-0-5">F</div>
-            <div class="canopy-square hidden"></div>
+            <div class="row">
+            <div id="canopy-north" class="canopy">
+                <p class="header">North</p>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-0-0">A</div>
+                <div class="canopy-square shown" id="square-0-1">B</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square shown" id="square-0-6">G</div>
-            <div class="canopy-square shown" id="square-0-7">H</div>
-            <div class="canopy-square shown" id="square-0-8">I</div>
-            <div class="canopy-square shown" id="square-0-9">J</div>
-            <div class="canopy-square shown" id="square-0-10">K</div>
-            <div class="canopy-square shown" id="square-0-11">L</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-0-2">C</div>
+                <div class="canopy-square shown" id="square-0-3">D</div>
+                <div class="canopy-square shown" id="square-0-4">E</div>
+                <div class="canopy-square shown" id="square-0-5">F</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square shown" id="square-0-12">M</div>
-            <div class="canopy-square shown" id="square-0-13">N</div>
-            <div class="canopy-square shown" id="square-0-14">O</div>
-            <div class="canopy-square shown" id="square-0-15">P</div>
-            <div class="canopy-square shown" id="square-0-16">Q</div>
-            <div class="canopy-square shown" id="square-0-17">R</div>
+                <div class="canopy-square shown" id="square-0-6">G</div>
+                <div class="canopy-square shown" id="square-0-7">H</div>
+                <div class="canopy-square shown" id="square-0-8">I</div>
+                <div class="canopy-square shown" id="square-0-9">J</div>
+                <div class="canopy-square shown" id="square-0-10">K</div>
+                <div class="canopy-square shown" id="square-0-11">L</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-0-18">S</div>
-            <div class="canopy-square shown" id="square-0-19">T</div>
-            <div class="canopy-square shown" id="square-0-20">U</div>
-            <div class="canopy-square shown" id="square-0-21">V</div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square shown" id="square-0-12">M</div>
+                <div class="canopy-square shown" id="square-0-13">N</div>
+                <div class="canopy-square shown" id="square-0-14">O</div>
+                <div class="canopy-square shown" id="square-0-15">P</div>
+                <div class="canopy-square shown" id="square-0-16">Q</div>
+                <div class="canopy-square shown" id="square-0-17">R</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-0-22">W</div>
-            <div class="canopy-square shown" id="square-0-23">X</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-0-18">S</div>
+                <div class="canopy-square shown" id="square-0-19">T</div>
+                <div class="canopy-square shown" id="square-0-20">U</div>
+                <div class="canopy-square shown" id="square-0-21">V</div>
+                <div class="canopy-square hidden">Z</div>
+
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-0-22">W</div>
+                <div class="canopy-square shown" id="square-0-23">X</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+            </div>
+
+            <div id="canopy-west" class="canopy">
+                <p class="header">West</p>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-1-0">A</div>
+                <div class="canopy-square shown" id="square-1-1">B</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-1-2">C</div>
+                <div class="canopy-square shown" id="square-1-3">D</div>
+                <div class="canopy-square shown" id="square-1-4">E</div>
+                <div class="canopy-square shown" id="square-1-5">F</div>
+                <div class="canopy-square hidden">Z</div>
+
+                <div class="canopy-square shown" id="square-1-6">G</div>
+                <div class="canopy-square shown" id="square-1-7">H</div>
+                <div class="canopy-square shown" id="square-1-8">I</div>
+                <div class="canopy-square shown" id="square-1-9">J</div>
+                <div class="canopy-square shown" id="square-1-10">K</div>
+                <div class="canopy-square shown" id="square-1-11">L</div>
+
+                <div class="canopy-square shown" id="square-1-12">M</div>
+                <div class="canopy-square shown" id="square-1-13">N</div>
+                <div class="canopy-square shown" id="square-1-14">O</div>
+                <div class="canopy-square shown" id="square-1-15">P</div>
+                <div class="canopy-square shown" id="square-1-16">Q</div>
+                <div class="canopy-square shown" id="square-1-17">R</div>
+
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-1-18">S</div>
+                <div class="canopy-square shown" id="square-1-19">T</div>
+                <div class="canopy-square shown" id="square-1-20">U</div>
+                <div class="canopy-square shown" id="square-1-21">V</div>
+                <div class="canopy-square hidden">Z</div>
+
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-1-22">W</div>
+                <div class="canopy-square shown" id="square-1-23">X</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+            </div>
         </div>
 
-        <div id="canopy-west" class="canopy">
-            <p class="header">West</p>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-1-0">A</div>
-            <div class="canopy-square shown" id="square-1-1">B</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
+        <div class="row">
+            <div id="canopy-east" class="canopy">
+                <p class="header">East</p>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-2-0">A</div>
+                <div class="canopy-square shown" id="square-2-1">B</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-1-2">C</div>
-            <div class="canopy-square shown" id="square-1-3">D</div>
-            <div class="canopy-square shown" id="square-1-4">E</div>
-            <div class="canopy-square shown" id="square-1-5">F</div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-2-2">C</div>
+                <div class="canopy-square shown" id="square-2-3">D</div>
+                <div class="canopy-square shown" id="square-2-4">E</div>
+                <div class="canopy-square shown" id="square-2-5">F</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square shown" id="square-1-6">G</div>
-            <div class="canopy-square shown" id="square-1-7">H</div>
-            <div class="canopy-square shown" id="square-1-8">I</div>
-            <div class="canopy-square shown" id="square-1-9">J</div>
-            <div class="canopy-square shown" id="square-1-10">K</div>
-            <div class="canopy-square shown" id="square-1-11">L</div>
+                <div class="canopy-square shown" id="square-2-6">G</div>
+                <div class="canopy-square shown" id="square-2-7">H</div>
+                <div class="canopy-square shown" id="square-2-8">I</div>
+                <div class="canopy-square shown" id="square-2-9">J</div>
+                <div class="canopy-square shown" id="square-2-10">K</div>
+                <div class="canopy-square shown" id="square-2-11">L</div>
 
-            <div class="canopy-square shown" id="square-1-12">M</div>
-            <div class="canopy-square shown" id="square-1-13">N</div>
-            <div class="canopy-square shown" id="square-1-14">O</div>
-            <div class="canopy-square shown" id="square-1-15">P</div>
-            <div class="canopy-square shown" id="square-1-16">Q</div>
-            <div class="canopy-square shown" id="square-1-17">R</div>
+                <div class="canopy-square shown" id="square-2-12">M</div>
+                <div class="canopy-square shown" id="square-2-13">N</div>
+                <div class="canopy-square shown" id="square-2-14">O</div>
+                <div class="canopy-square shown" id="square-2-15">P</div>
+                <div class="canopy-square shown" id="square-2-16">Q</div>
+                <div class="canopy-square shown" id="square-2-17">R</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-1-18">S</div>
-            <div class="canopy-square shown" id="square-1-19">T</div>
-            <div class="canopy-square shown" id="square-1-20">U</div>
-            <div class="canopy-square shown" id="square-1-21">V</div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-2-18">S</div>
+                <div class="canopy-square shown" id="square-2-19">T</div>
+                <div class="canopy-square shown" id="square-2-20">U</div>
+                <div class="canopy-square shown" id="square-2-21">V</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-1-22">W</div>
-            <div class="canopy-square shown" id="square-1-23">X</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-        </div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-2-22">W</div>
+                <div class="canopy-square shown" id="square-2-23">X</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+            </div>
 
-        <div id="canopy-east" class="canopy">
-            <p class="header">East</p>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-2-0">A</div>
-            <div class="canopy-square shown" id="square-2-1">B</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
+            <div id="canopy-south" class="canopy">
+                <p class="header">South</p>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-3-0">A</div>
+                <div class="canopy-square shown" id="square-3-1">B</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-2-2">C</div>
-            <div class="canopy-square shown" id="square-2-3">D</div>
-            <div class="canopy-square shown" id="square-2-4">E</div>
-            <div class="canopy-square shown" id="square-2-5">F</div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-3-2">C</div>
+                <div class="canopy-square shown" id="square-3-3">D</div>
+                <div class="canopy-square shown" id="square-3-4">E</div>
+                <div class="canopy-square shown" id="square-3-5">F</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square shown" id="square-2-6">G</div>
-            <div class="canopy-square shown" id="square-2-7">H</div>
-            <div class="canopy-square shown" id="square-2-8">I</div>
-            <div class="canopy-square shown" id="square-2-9">J</div>
-            <div class="canopy-square shown" id="square-2-10">K</div>
-            <div class="canopy-square shown" id="square-2-11">L</div>
+                <div class="canopy-square shown" id="square-3-6">G</div>
+                <div class="canopy-square shown" id="square-3-7">H</div>
+                <div class="canopy-square shown" id="square-3-8">I</div>
+                <div class="canopy-square shown" id="square-3-9">J</div>
+                <div class="canopy-square shown" id="square-3-10">K</div>
+                <div class="canopy-square shown" id="square-3-11">L</div>
 
-            <div class="canopy-square shown" id="square-2-12">M</div>
-            <div class="canopy-square shown" id="square-2-13">N</div>
-            <div class="canopy-square shown" id="square-2-14">O</div>
-            <div class="canopy-square shown" id="square-2-15">P</div>
-            <div class="canopy-square shown" id="square-2-16">Q</div>
-            <div class="canopy-square shown" id="square-2-17">R</div>
+                <div class="canopy-square shown" id="square-3-12">M</div>
+                <div class="canopy-square shown" id="square-3-13">N</div>
+                <div class="canopy-square shown" id="square-3-14">O</div>
+                <div class="canopy-square shown" id="square-3-15">P</div>
+                <div class="canopy-square shown" id="square-3-16">Q</div>
+                <div class="canopy-square shown" id="square-3-17">R</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-2-18">S</div>
-            <div class="canopy-square shown" id="square-2-19">T</div>
-            <div class="canopy-square shown" id="square-2-20">U</div>
-            <div class="canopy-square shown" id="square-2-21">V</div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-3-18">S</div>
+                <div class="canopy-square shown" id="square-3-19">T</div>
+                <div class="canopy-square shown" id="square-3-20">U</div>
+                <div class="canopy-square shown" id="square-3-21">V</div>
+                <div class="canopy-square hidden">Z</div>
 
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-2-22">W</div>
-            <div class="canopy-square shown" id="square-2-23">X</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-        </div>
-
-        <div id="canopy-south" class="canopy">
-            <p class="header">South</p>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-3-0">A</div>
-            <div class="canopy-square shown" id="square-3-1">B</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-3-2">C</div>
-            <div class="canopy-square shown" id="square-3-3">D</div>
-            <div class="canopy-square shown" id="square-3-4">E</div>
-            <div class="canopy-square shown" id="square-3-5">F</div>
-            <div class="canopy-square hidden"></div>
-
-            <div class="canopy-square shown" id="square-3-6">G</div>
-            <div class="canopy-square shown" id="square-3-7">H</div>
-            <div class="canopy-square shown" id="square-3-8">I</div>
-            <div class="canopy-square shown" id="square-3-9">J</div>
-            <div class="canopy-square shown" id="square-3-10">K</div>
-            <div class="canopy-square shown" id="square-3-11">L</div>
-
-            <div class="canopy-square shown" id="square-3-12">M</div>
-            <div class="canopy-square shown" id="square-3-13">N</div>
-            <div class="canopy-square shown" id="square-3-14">O</div>
-            <div class="canopy-square shown" id="square-3-15">P</div>
-            <div class="canopy-square shown" id="square-3-16">Q</div>
-            <div class="canopy-square shown" id="square-3-17">R</div>
-
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-3-18">S</div>
-            <div class="canopy-square shown" id="square-3-19">T</div>
-            <div class="canopy-square shown" id="square-3-20">U</div>
-            <div class="canopy-square shown" id="square-3-21">V</div>
-            <div class="canopy-square hidden"></div>
-
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square shown" id="square-3-22">W</div>
-            <div class="canopy-square shown" id="square-3-23">X</div>
-            <div class="canopy-square hidden"></div>
-            <div class="canopy-square hidden"></div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square shown" id="square-3-22">W</div>
+                <div class="canopy-square shown" id="square-3-23">X</div>
+                <div class="canopy-square hidden">Z</div>
+                <div class="canopy-square hidden">Z</div>
+            </div>
         </div>
     </div>
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -49,6 +49,19 @@
         margin-right: -3px;
     }
 
+    @media (max-width: 1370px) {
+        .canopy-square {
+            margin-right: -2px;
+        }
+
+        .canopy-square:nth-child(6n),
+        .canopy-square:nth-child(6n-1),
+        .canopy-square:nth-child(6n-3),
+        .canopy-square:nth-child(6n-4) {
+            margin-right: -3px !important;
+        }
+    }
+
     .canopy-square.hidden {
         visibility: hidden;
     }

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_view.html
@@ -38,12 +38,15 @@
         width: 50px;
         height: 50px;
         outline: 1px solid;
-        margin-top: 1px;
-
         text-align: center;
         line-height: 50px;
         font-size: 2em;
         font-weight: bold;
+
+        /* Don't remove - fixes weird spacing */
+        background-color: white;
+        margin-top: 1px;
+        margin-right: -3px;
     }
 
     .canopy-square.hidden {


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #211 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Materialize form input
- [X] Make cardinal boxes responsive

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. `docker-compose up`
2. Go to a site and try adding Canopy Cover Survey data

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

There should be two cardinal boxes per row, and if you shrink your browser it should collapse into a single column.

@osuosl/devs
