### PR TITLE
enforce creation of all 5 zones per valid riparian transect

### DIFF
--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -145,8 +145,15 @@ class Canopy_Cover_Form(forms.ModelForm):
                   'north_cc', 'west_cc', 'east_cc', 'south_cc')
 
 
-# the following form is never used in views.py and can probably be deleted.
 class TransectZoneForm(forms.ModelForm):
+    # The following override is neccessary so that when the user chooses not to
+    # fill in an individual zone form in a 5-zone inline formset, the zone form
+    # is not ignored and is saved as a new zone object with its model-specified
+    # default values of 0 (for the numerical fields) and '' (for the comments
+    # field).
+    def has_changed(self):
+        return True
+
     class Meta:
         model = TransectZone
         widgets = {
@@ -163,24 +170,15 @@ class BaseZoneInlineFormSet(BaseInlineFormSet):
             return
 
         # ...plus custom cleaning to check for blank zones
-        print('\nWE GET HERE\n')
         blank = 0
         for form in self.forms:
-            if form.cleaned_data:
-                conifers = form.cleaned_data['conifers']
-                print(conifers)
-                hardwoods = form.cleaned_data['hardwoods']
-                print(hardwoods)
-                shrubs = form.cleaned_data['shrubs']
-                print(shrubs)
-
             # if form's conifers, hardwoods, shrubs ALL 0, inc. 'blank' count
-                if (conifers == 0 and hardwoods == 0 and shrubs == 0):
-                    blank += 1
-                print("blank is ", blank)
-        
-        if blank == 5 or not (self.has_changed()): # All zones are blank. Complain
-            print("gdi!!")
+            if (form.cleaned_data['conifers'] == 0 and
+                    form.cleaned_data['hardwoods'] == 0 and
+                    form.cleaned_data['shrubs'] == 0):
+                blank += 1
+
+        if blank == 5:
             raise forms.ValidationError('At least one zone must have at ' +
                                         'least one value greater than 0.')
 

--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -931,7 +931,7 @@ class TransectZone(models.Model):
                                                  verbose_name=_('hardwoods'))
     shrubs = models.PositiveSmallIntegerField(default=0, null=True,
                                               verbose_name=_('shrubs'))
-    comments = models.TextField(blank=True, null=True,
+    comments = models.TextField(blank=True,
                                 verbose_name=_('additional comments'))
 
     test_objects = TransectZoneManager()

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -18,15 +18,15 @@
 {% endblock%}
 
 {% block content %}
-    <div class="container">
-        {% if messages %}
-            {% for message in messages %}
-            <strong>{{ message }}<strong>
-            {% endfor %}
-        {% endif %}
+<div class="container">
+{% if messages %}
+    {% for message in messages %}
+    <strong>{{ message }}<strong>
+    {% endfor %}
+{% endif %}
 
-    {% if added %}
-    <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
+{% if added %}
+<strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
 
 {% else %}
     <h3 align ="center">
@@ -61,7 +61,6 @@
 
 
             <div class="col s6">
-            <div class="row">
                 <div class="input-field">
                     <label for="{{ transect_form.weather.id_for_label }}">
                         {{ transect_form.weather.label }}
@@ -87,8 +86,8 @@
         <br>
 
         {{ zone_formset.management_form }}
-        {{ zone_formset.non_field_errors }}
         <table> <!-- zones subtable -->
+            <tr>{{ zone_formset.non_form_errors }}</tr>
             <tr>
                 <th>{{ 'zone'|get_zone_labels }}</th>
                 <th>{{ 'conifers'|get_zone_labels }}</th>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -59,7 +59,9 @@
                 </div>
             </div>
 
+
             <div class="col s6">
+            <div class="row">
                 <div class="input-field">
                     <label for="{{ transect_form.weather.id_for_label }}">
                         {{ transect_form.weather.label }}
@@ -85,8 +87,8 @@
         <br>
 
         {{ zone_formset.management_form }}
+        {{ zone_formset.non_field_errors }}
         <table> <!-- zones subtable -->
-            <tr>{{ zone_formset.non_field_errors }}</tr>
             <tr>
                 <th>{{ 'zone'|get_zone_labels }}</th>
                 <th>{{ 'conifers'|get_zone_labels }}</th>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -86,6 +86,7 @@
 
         {{ zone_formset.management_form }}
         <table> <!-- zones subtable -->
+            <tr>{{ zone_formset.non_field_errors }}</tr>
             <tr>
                 <th>{{ 'zone'|get_zone_labels }}</th>
                 <th>{{ 'conifers'|get_zone_labels }}</th>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -18,9 +18,15 @@
 {% endblock%}
 
 {% block content %}
-<div class="container">
-{% if added %}
-<strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
+    <div class="container">
+        {% if messages %}
+            {% for message in messages %}
+            <strong>{{ message }}<strong>
+            {% endfor %}
+        {% endif %}
+
+    {% if added %}
+    <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
 
 {% else %}
     <h3 align ="center">

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_view.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load filters %}
 {% block title %}{% trans "View Riparian Area Transect Data" %}{% endblock %}
-{% block body_title %}{% trans "View Ripariant Area Transect Data" %}{% endblock %}
+{% block body_title %}{% trans "View Riparian Area Transect Data" %}{% endblock %}
 
 {% block scripts %}
     <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>

--- a/streamwebs_frontend/streamwebs/tests/forms/test_transect_forms.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_transect_forms.py
@@ -24,6 +24,10 @@ class TransectZoneFormTestCase(TestCase):
         for field in self.optional_fields:
             self.assertEqual(zone_form.base_fields[field].required, False)
 
+    def test_override_has_changed(self):
+        zone_form = TransectZoneForm()
+        self.assertEqual(zone_form.has_changed(), True)
+
 
 class RiparianTransectFormTestCase(TestCase):
 

--- a/streamwebs_frontend/streamwebs/tests/forms/test_zone_formset.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_zone_formset.py
@@ -1,0 +1,140 @@
+from django.test import TestCase
+from django.forms import inlineformset_factory
+from streamwebs.forms import BaseZoneInlineFormSet, TransectZoneForm
+from streamwebs.models import RiparianTransect, TransectZone, Site
+
+
+class BaseZoneFormSetTestCase(TestCase):
+
+    def setUp(self):
+        # create the inline formset using inline formset factory
+        self.ZoneFormSet = inlineformset_factory(
+                RiparianTransect, TransectZone, form=TransectZoneForm,
+                extra=5,
+                formset=BaseZoneInlineFormSet)
+
+        # create valid transect (+ site) for future assignation
+        site = Site.test_objects.create_site('Site')
+        self.transect = RiparianTransect.test_objects.create_transect(
+                'School', '2015-01-01 11:56', site)
+
+    def test_zeroed_zones_with_comments(self):
+        """All zone values 0; some zones have comments. Error raised"""
+        # make data dict; pass to formset
+        data = {
+                'transect-TOTAL_FORMS': '5',
+                'transect-INITIAL_FORMS': '0',
+                'transect-MAX_NUM_FORMS': '5',
+
+                'transect-0-conifers': 0,
+                'transect-0-hardwoods': 0,
+                'transect-0-shrubs': 0,
+                'transect-0-comments': '',
+
+                'transect-1-conifers': 0,
+                'transect-1-hardwoods': 0,
+                'transect-1-shrubs': 0,
+                'transect-1-comments': 'comments for zone 2',
+
+                'transect-2-conifers': 0,
+                'transect-2-hardwoods': 0,
+                'transect-2-shrubs': 0,
+                'transect-2-comments': '',
+
+                'transect-3-conifers': 0,
+                'transect-3-hardwoods': 0,
+                'transect-3-shrubs': 0,
+                'transect-3-comments': 'comments for zone 4',
+
+                'transect-4-conifers': 0,
+                'transect-4-hardwoods': 0,
+                'transect-4-shrubs': 0,
+                'transect-4-comments': 'comments for zone 5'
+                }
+        formset = self.ZoneFormSet(data, instance=self.transect)
+        # assert formset is NOT valid
+        self.assertFalse(formset.is_valid())
+        # assert there are no regular form field errors
+        self.assertEquals(formset.errors, [{}, {}, {}, {}, {}])
+        # assert there are non form field errors
+        self.assertEquals(
+            formset.non_form_errors(),
+            ['At least one zone must have at least one value greater than 0.'])
+
+    def test_completely_blank_zones(self):
+        """All zone values 0; no comments. Error raised"""
+        # same as previours test but without comments
+        data = {
+                'transect-TOTAL_FORMS': '5',
+                'transect-INITIAL_FORMS': '0',
+                'transect-MAX_NUM_FORMS': '5',
+
+                'transect-0-conifers': 0,
+                'transect-0-hardwoods': 0,
+                'transect-0-shrubs': 0,
+                'transect-0-comments': '',
+
+                'transect-1-conifers': 0,
+                'transect-1-hardwoods': 0,
+                'transect-1-shrubs': 0,
+                'transect-1-comments': '',
+
+                'transect-2-conifers': 0,
+                'transect-2-hardwoods': 0,
+                'transect-2-shrubs': 0,
+                'transect-2-comments': '',
+
+                'transect-3-conifers': 0,
+                'transect-3-hardwoods': 0,
+                'transect-3-shrubs': 0,
+                'transect-3-comments': '',
+
+                'transect-4-conifers': 0,
+                'transect-4-hardwoods': 0,
+                'transect-4-shrubs': 0,
+                'transect-4-comments': ''
+                }
+        formset = self.ZoneFormSet(data, instance=self.transect)
+        self.assertFalse(formset.is_valid())
+        self.assertEquals(formset.errors, [{}, {}, {}, {}, {}])
+        self.assertEquals(
+            formset.non_form_errors(),
+            ['At least one zone must have at least one value greater than 0.'])
+
+    def test_bare_minimum(self):
+        """Only one zone has value greater than 0. All zones count as valid"""
+        data = {
+                'transect-TOTAL_FORMS': '5',
+                'transect-INITIAL_FORMS': '0',
+                'transect-MAX_NUM_FORMS': '5',
+
+                'transect-0-conifers': 0,
+                'transect-0-hardwoods': 0,
+                'transect-0-shrubs': 0,
+                'transect-0-comments': '',
+
+                'transect-1-conifers': 0,
+                'transect-1-hardwoods': 0,
+                'transect-1-shrubs': 0,
+                'transect-1-comments': '',
+
+                # third form satisfies the minimum requirement for valid zones
+                'transect-2-conifers': 0,
+                'transect-2-hardwoods': 1,
+                'transect-2-shrubs': 0,
+                'transect-2-comments': '',
+
+                'transect-3-conifers': 0,
+                'transect-3-hardwoods': 0,
+                'transect-3-shrubs': 0,
+                'transect-3-comments': '',
+
+                'transect-4-conifers': 0,
+                'transect-4-hardwoods': 0,
+                'transect-4-shrubs': 0,
+                'transect-4-comments': ''
+                }
+        formset = self.ZoneFormSet(data, instance=self.transect)
+        self.assertTrue(formset.is_valid())
+        self.assertEquals(formset.errors, [{}, {}, {}, {}, {}])
+        self.assertEquals(formset.non_form_errors(), [])

--- a/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
@@ -35,6 +35,7 @@ class AddTransectTestCase(TestCase):
         When the user submits a form with all required fields filled
         appropriately, the user should see a success message
         """
+        print("START VALID TEST.")
         site = Site.test_objects.create_site('Site Name')
         response = self.client.post(
             reverse(
@@ -86,10 +87,12 @@ class AddTransectTestCase(TestCase):
                     ),
             status_code=302,
             target_status_code=200)
+        print("END VALID TEST")
 
     def test_view_with_invalid_zones_with_notes(self):
         """When counts for all zones are 0, can't submit even if notes exist"""
-        site = Site.test_objects.create_site('Site Name')
+        print("START INVALID WITH NOTES")
+        site = Site.test_objects.create_site('Bad Transect with Notes')
         response = self.client.post(
             reverse(
                 'streamwebs:riparian_transect_edit',
@@ -138,10 +141,15 @@ class AddTransectTestCase(TestCase):
         self.assertTemplateNotUsed(
             response,
             'streamwebs/datasheets/riparian_transect_view.html')
+        self.assertFormsetError(response, 'zone_formset', None, None, 'At least one zone must have at least one value greater than 0.') 
+        self.assertFalse(RiparianTransect.objects.filter(site=site.id).exists())
+
+        print("END INVALID WITH NOTES")
 
     def test_view_with_invalid_zones_without_notes(self):
         """Can't submit when all zones completely blank/zeroed out"""
-        site = Site.test_objects.create_site('Site Name')
+        print("START INVALID WITHOUT NOTES.")
+        site = Site.test_objects.create_site('Bad Transect without Notes')
         response = self.client.post(
             reverse(
                 'streamwebs:riparian_transect_edit',
@@ -184,12 +192,12 @@ class AddTransectTestCase(TestCase):
                     'transect-4-comments': ''
                 }
         )
-        self.assertTemplateUsed(
-            response,
-            'streamwebs/datasheets/riparian_transect_edit.html')
         self.assertTemplateNotUsed(
             response,
             'streamwebs/datasheets/riparian_transect_view.html')
+        self.assertFormsetError(response, 'zone_formset', None, None, 'At least one zone must have at least one value greater than 0.') 
+        self.assertFalse(RiparianTransect.objects.filter(site=site.id).exists())
+        print("END INVALID WITHOUT NOTES.")
 
     def test_view_with_not_logged_in_user(self):
         """

--- a/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_rip_transect_edit_view.py
@@ -30,7 +30,7 @@ class AddTransectTestCase(TestCase):
         self.assertFormError(response, 'transect_form', 'school',
                              'This field is required.')
 
-    def test_view_with_good_data(self):
+    def test_view_with_valid_zones(self):
         """
         When the user submits a form with all required fields filled
         appropriately, the user should see a success message
@@ -86,6 +86,110 @@ class AddTransectTestCase(TestCase):
                     ),
             status_code=302,
             target_status_code=200)
+
+    def test_view_with_invalid_zones_with_notes(self):
+        """When counts for all zones are 0, can't submit even if notes exist"""
+        site = Site.test_objects.create_site('Site Name')
+        response = self.client.post(
+            reverse(
+                'streamwebs:riparian_transect_edit',
+                kwargs={'site_slug': site.site_slug}
+            ), {
+                    'school': self.school.id,
+                    'date_time': '2016-07-18 14:09:07',
+                    'weather': 'cloudy',
+                    'site': site.id,
+                    'slope': 5,
+                    'notes': 'notes',
+
+                    'transect-TOTAL_FORMS': '5',
+                    'transect-INITIAL_FORMS': '0',
+                    'transect-MAX_NUM_FORMS': '5',
+
+                    'transect-0-conifers': 0,
+                    'transect-0-hardwoods': 0,
+                    'transect-0-shrubs': 0,
+                    'transect-0-comments': '1 comments',
+
+                    'transect-1-conifers': 0,
+                    'transect-1-hardwoods': 0,
+                    'transect-1-shrubs': 0,
+                    'transect-1-comments': '2 comments',
+
+                    'transect-2-conifers': 0,
+                    'transect-2-hardwoods': 0,
+                    'transect-2-shrubs': 0,
+                    'transect-2-comments': '3 comments',
+
+                    'transect-3-conifers': 0,
+                    'transect-3-hardwoods': 0,
+                    'transect-3-shrubs': 0,
+                    'transect-3-comments': '4 comments',
+
+                    'transect-4-conifers': 0,
+                    'transect-4-hardwoods': 0,
+                    'transect-4-shrubs': 0,
+                    'transect-4-comments': '5 comments'
+                    }
+        )
+        self.assertTemplateUsed(
+            response,
+            'streamwebs/datasheets/riparian_transect_edit.html')
+        self.assertTemplateNotUsed(
+            response,
+            'streamwebs/datasheets/riparian_transect_view.html')
+
+    def test_view_with_invalid_zones_without_notes(self):
+        """Can't submit when all zones completely blank/zeroed out"""
+        site = Site.test_objects.create_site('Site Name')
+        response = self.client.post(
+            reverse(
+                'streamwebs:riparian_transect_edit',
+                kwargs={'site_slug': site.site_slug}
+            ), {
+                    'school': self.school.id,
+                    'date_time': '2016-07-18 14:09:07',
+                    'weather': 'cloudy',
+                    'site': site.id,
+                    'slope': 5,
+                    'notes': 'notes',
+        
+                    'transect-TOTAL_FORMS': '5',
+                    'transect-INITIAL_FORMS': '0',
+                    'transect-MAX_NUM_FORMS': '5',
+        
+                    'transect-0-conifers': 0,
+                    'transect-0-hardwoods': 0,
+                    'transect-0-shrubs': 0,
+                    'transect-0-comments': '',
+        
+                    'transect-1-conifers': 0,
+                    'transect-1-hardwoods': 0,
+                    'transect-1-shrubs': 0,
+                    'transect-1-comments': '',
+        
+                    'transect-2-conifers': 0,
+                    'transect-2-hardwoods': 0,
+                    'transect-2-shrubs': 0,
+                    'transect-2-comments': '',
+        
+                    'transect-3-conifers': 0,
+                    'transect-3-hardwoods': 0,
+                    'transect-3-shrubs': 0,
+                    'transect-3-comments': '',
+        
+                    'transect-4-conifers': 0,
+                    'transect-4-hardwoods': 0,
+                    'transect-4-shrubs': 0,
+                    'transect-4-comments': ''
+                }
+        )
+        self.assertTemplateUsed(
+            response,
+            'streamwebs/datasheets/riparian_transect_edit.html')
+        self.assertTemplateNotUsed(
+            response,
+            'streamwebs/datasheets/riparian_transect_view.html')
 
     def test_view_with_not_logged_in_user(self):
         """


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #210 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Error message if riparian transect data sheet doesn't have at least one zone that has at least one numerical value greater than 0.
- [X] Per the restriction above, if there are zones that are all 0s, they are saved just like that. Each valid data sheet gets 5 zones no matter what.
- [X] Assigns zone numbers to each created zone; this wasn't being done previously.

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run tests
2. Load or create Site and School data as needed. Then go to http://localhost:8000/sites/[site-slug]/transect/edit/
3. Provide valid data for the general part of the main riparian transect form. For the zones table, try the following cases: 1) completely blank, where each zone has all 0s and no comments; 2) blank, where each zone has all 0s but some may have comments; 3) almost blank, with four zones completely blank and one zone with one nonzero numerical value. The first two cases should prevent form submission and print an error (see Expected Output), and the third case should allow you to submit the form successfully.
4. Check the database to verify your objects were created as expected-- for each riparian transect object created, 5 zones with its ID are also created: ``python manage.py dbshell`` and ``select * from streamwebs_ripariantransect;`` and ``select * from streamwebs_transectzone;``

## Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->
### Automated tests:
```
[root@a9b65de7a891 streamwebs_frontend]# python manage.py test streamwebs/tests/*    
Creating test database for alias 'default'...
admin group created; permissions added
............................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 204 tests in 8.337s

OK
```
### Manual testing: error message (unstyled),
![zone_error](https://cloud.githubusercontent.com/assets/9158473/24118633/b76efa8c-0d6b-11e7-9946-69f4e96adeed.png)

### or a redirect to the new data sheet (note the completeness and the order of the zones):
![ordered_zones](https://cloud.githubusercontent.com/assets/9158473/24118639/beab41f2-0d6b-11e7-96f7-916b869690b3.png)

### In the database:
Riparian transect object:
```
streamwebs=# select * from streamwebs_ripariantransect;
 id |              school               |       date_time        |  weather   | slope  |    notes     | nid | site_id 
----+-----------------------------------+------------------------+------------+--------+--------------+-----+---------
...
 30 | Durham Elementary School          | 2017-03-20 19:27:25+00 | fdfdf      |  2.993 |              |     |     190
```
Associated transect zones:
```
streamwebs=# select * from streamwebs_transectzone;
 id | zone_num | conifers | hardwoods | shrubs |    comments     | transect_id 
----+----------+----------+-----------+--------+-----------------+-------------
...
 35 | 1        |        0 |         0 |      0 |                 |          30
 36 | 2        |        0 |         0 |      0 |                 |          30
 37 | 3        |        0 |         0 |      0 |                 |          30
 38 | 4        |        0 |         1 |      0 |                 |          30
 39 | 5        |        0 |         0 |      0 |                 |          30
```