### PR TITLE
Fix horizontal radio buttons for Django 1.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ python:
 env:
   global:
     - POSTGRES_DB=streamwebs POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres_pw PG_HOST=localhost
-  matrix:
-    - DJANGO_VERSION=1.10.7
 
 install:
   - "pip install -r requirements.txt"

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -17,6 +17,8 @@ RUN npm install -g bower
 
 COPY requirements.txt /home/centos/
 
-RUN pip install -r /home/centos/requirements.txt
+RUN pip install --upgrade pip
+
+RUN pip install --upgrade -r /home/centos/requirements.txt
 
 #RUN echo 'source /opt/streamwebs/dockerfiles/startup.sh' >> /root/.bashrc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.7
+Django
 Jinja2
 Pillow
 MarkupSafe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django==1.11
 Jinja2
 Pillow
 MarkupSafe

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -55,10 +55,17 @@ class UserProfileForm(forms.ModelForm):
         fields = ('school', 'birthdate')
 
 
-class HorizontalRadioRenderer(forms.RadioSelect.renderer):
-    ''' Renders radio buttons horizontally '''
-    def render(self):
-        return mark_safe(u'\n'.join([u'%s\n' % w for w in self]))
+class HorizontalRadioSelect(forms.RadioSelect):
+    """ Renders radio buttons horizontally """
+    def __init__(self, *args, **kwargs):
+        super(HorizontalRadioSelect, self).__init__(*args, **kwargs)
+        # In Python 3.x, just do:
+        # super().__init__(*args, **kwargs)
+
+        css_style = 'style="display: inline-block; margin-right: 10px;"'
+
+        self.renderer.inner_html = '<li ' + css_style + '>' \
+                                   '{choice_value}{sub_widgets}</li>'
 
 
 class MacroinvertebratesForm(forms.ModelForm):
@@ -81,12 +88,9 @@ class WQForm(forms.ModelForm):
     class Meta:
         model = Water_Quality
         widgets = {
-            'fish_present':
-                forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'water_temp_unit':
-                forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'air_temp_unit':
-                forms.RadioSelect(renderer=HorizontalRadioRenderer),
+            'fish_present': HorizontalRadioSelect(),
+            'water_temp_unit': HorizontalRadioSelect(),
+            'air_temp_unit': HorizontalRadioSelect(),
             'notes':
                 forms.Textarea(attrs={'class': 'materialize-textarea'})
         }
@@ -108,14 +112,12 @@ class WQSampleForm(forms.ModelForm):
     class Meta:
         model = WQ_Sample
         widgets = {
-            'water_temp_tool':
-                forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'air_temp_tool':
-                forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'oxygen_tool': forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'pH_tool': forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'turbid_tool': forms.RadioSelect(renderer=HorizontalRadioRenderer),
-            'salt_tool': forms.RadioSelect(renderer=HorizontalRadioRenderer)
+            'water_temp_tool': HorizontalRadioSelect(),
+            'air_temp_tool': HorizontalRadioSelect(),
+            'oxygen_tool': HorizontalRadioSelect(),
+            'pH_tool': HorizontalRadioSelect(),
+            'turbid_tool': HorizontalRadioSelect(),
+            'salt_tool': HorizontalRadioSelect()
         }
         fields = (
             'water_temperature', 'water_temp_tool',

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -55,19 +55,6 @@ class UserProfileForm(forms.ModelForm):
         fields = ('school', 'birthdate')
 
 
-class HorizontalRadioSelect(forms.RadioSelect):
-    """ Renders radio buttons horizontally """
-    def __init__(self, *args, **kwargs):
-        super(HorizontalRadioSelect, self).__init__(*args, **kwargs)
-        # In Python 3.x, just do:
-        # super().__init__(*args, **kwargs)
-
-        css_style = 'style="display: inline-block; margin-right: 10px;"'
-
-        self.renderer.inner_html = '<li ' + css_style + '>' \
-                                   '{choice_value}{sub_widgets}</li>'
-
-
 class MacroinvertebratesForm(forms.ModelForm):
     school = forms.ModelChoiceField(queryset=School.objects.all())
 
@@ -88,9 +75,9 @@ class WQForm(forms.ModelForm):
     class Meta:
         model = Water_Quality
         widgets = {
-            'fish_present': HorizontalRadioSelect(),
-            'water_temp_unit': HorizontalRadioSelect(),
-            'air_temp_unit': HorizontalRadioSelect(),
+            'fish_present': forms.RadioSelect(),
+            'water_temp_unit': forms.RadioSelect(),
+            'air_temp_unit': forms.RadioSelect(),
             'notes':
                 forms.Textarea(attrs={'class': 'materialize-textarea'})
         }
@@ -112,12 +99,12 @@ class WQSampleForm(forms.ModelForm):
     class Meta:
         model = WQ_Sample
         widgets = {
-            'water_temp_tool': HorizontalRadioSelect(),
-            'air_temp_tool': HorizontalRadioSelect(),
-            'oxygen_tool': HorizontalRadioSelect(),
-            'pH_tool': HorizontalRadioSelect(),
-            'turbid_tool': HorizontalRadioSelect(),
-            'salt_tool': HorizontalRadioSelect()
+            'water_temp_tool': forms.RadioSelect(),
+            'air_temp_tool': forms.RadioSelect(),
+            'oxygen_tool': forms.RadioSelect(),
+            'pH_tool': forms.RadioSelect(),
+            'turbid_tool': forms.RadioSelect(),
+            'salt_tool': forms.RadioSelect()
         }
         fields = (
             'water_temperature', 'water_temp_tool',

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import User
 from django import forms
 from django.forms import BaseInlineFormSet
 from django.utils.translation import ugettext_lazy as _
-from django.utils.safestring import mark_safe
 from captcha.fields import ReCaptchaField
 
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality.html
@@ -45,7 +45,7 @@
         <div class="infogroup">
             <p>{{ wq_form.site.errors | striptags }}</p>
             <div class="row">
-                <div class="col s6">
+                <div class="col s12">
                     <div class="input-field">
                         <label for="{{ wq_form.date.id_for_label }}">{{ wq_form.date.label }}</label>
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #244.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Change horizontal radio button renderer to work with template-based rendering in Django 1.11.
- [X] Break streamwebs from working in Django <= 1.10. Thankfully, 1.11 is an LTS release.
- [X] Extend the date field across the whole page on the WQ view (a minor change we've been meaning to do that kind of fit in this PR).

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run the tests.
2. View the add Water Quality data page.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

Tests should pass and the page should have horizontal radio buttons.

@osuosl/devs