### PR TITLE
super admin user promotion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mock
 pep8
 psycopg2
 requests
-wsgiref
 flake8
 django-recaptcha
 django-queryset-csv
+wsgiref

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ docutils
 mock
 pep8
 psycopg2
-requests
+wsgiref
 flake8
 django-recaptcha
 django-queryset-csv
-wsgiref
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ wsgiref
 flake8
 django-recaptcha
 django-queryset-csv
-requests
+requests==2.13.0

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -260,3 +260,18 @@ class StatisticsForm(forms.Form):
         widget=forms.DateInput(attrs={'class': 'datepicker'}),
         label=_('ending on'), required=False
     )
+
+
+class AdminPromotionForm(forms.Form):
+    PERM_OPTIONS = (
+        ('add_admin', _('Add to Admin group')),
+        ('del_admin', _('Remove from Admin group')),
+        ('add_stats', _('Grant permission to view the Statistics page')),
+        ('add_upload', _('Grant permission to upload to the Resources page')),
+        ('del_stats', _('Revoke permission to view the Statistics page')),
+        ('del_upload', _('Revoke permission to upload to the Resources page')),
+    )
+
+    users = forms.ModelMultipleChoiceField(queryset=User.objects.all(),
+                                           widget=forms.SelectMultiple)
+    perms = forms.ChoiceField(choices=PERM_OPTIONS)

--- a/streamwebs_frontend/streamwebs/signals.py
+++ b/streamwebs_frontend/streamwebs/signals.py
@@ -23,5 +23,5 @@ def init_groups_and_perms(sender, **kwargs):
 
     admin, created = Group.objects.get_or_create(name='admin')
     if created:
-        admin.permissions.add(can_upload, can_promote, can_view_stats)
+        admin.permissions.add(can_upload, can_view_stats)
         print("admin group created; permissions added")

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -8,49 +8,49 @@
 {% block content %}
 <div class="container">
 {% if msgs %}
-    {% for message in msgs %}
-    <strong>{{ message }}</strong><br>
-    {% endfor %}
+  {% for message in msgs %}
+  <strong>{{ message }}</strong><br>
+  {% endfor %}
 {% endif %}
 
-    <form id='promo_form' method='post'>
-        {% csrf_token %}
-        {{ promo_form.as_p }}
-        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='{% trans 'Apply' %}'/>
-    </form>
+  <form id='promo_form' method='post'>
+    {% csrf_token %}
+    {{ promo_form.as_p }}
+    <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='{% trans 'Apply' %}'/>
+  </form>
 
-    {% for user in users %}
-        {% if user in users_list.staff %}
-        {{ user.username }}: is a super admin<br>
-        {% elif user in users_list.admin %}
-        {{ user.username }}: is an admin<br>
-        {% elif user in users_list.stats %}
-        {{ user.username }}: can view the Statistics page<br>
-        {% elif user in users_list.upload %}
-        {{ user.username }}: can upload new resources to the Resources page<br>
-        {% elif user in users_list.none %}
-        {{ user.username }}: does not have any special permissions<br>
-        {% endif %}
+  {% for user in page_of_users %}
+    {% for user_key, info in user_info.items %}
+      {% if user.username == user_key.username %}
+        {{ user_key }}
+        {% for perm, status in info.items %}
+          {% if status == True %}
+          || {{ perm }}
+          {% endif %}
+        {% endfor %}
+        <br>
+      {% endif %}
     {% endfor %}
+  {% endfor %}
 
-    <div class="pagination">
-        <span class="step-links">
-            {% if users.has_previous %}
-                <a href="?page={{ users.previous_page_number }}">previous</a>
-            {% endif %}
+  <div class="pagination">
+    <span class="step-links">
+      {% if page_of_users.has_previous %}
+        <a href="?page={{ page_of_users.previous_page_number }}">previous</a>
+      {% endif %}
 
-            <span class="current">
-                Page {{ users.number }} of {{ users.paginator.num_pages }}.
-            </span>
+      <span class="current">
+        Page {{ page_of_users.number }} of {{ page_of_users.paginator.num_pages }}.
+      </span>
 
-            {% if users.has_next %}
-                <a href="?page={{ users.next_page_number }}">next</a>
-            {% endif %}
-        </span>
-    </div>
+      {% if page_of_users.has_next %}
+        <a href="?page={{ page_of_users.next_page_number }}">next</a>
+      {% endif %}
+    </span>
+  </div>
 
 {% block scripts %}
-    <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>
+  <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>
 {% endblock %}
 
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -19,14 +19,35 @@
         <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='{% trans 'Apply' %}'/>
     </form>
 
-    {% if users_list %}
-        {% for user, perm in users_list.items %}
-        <ul>
-            <li>{{ user }}: {{ perm }}</li>
-        </ul>
-        {% endfor %}
-    {% endif %}
-</div>
+    {% for user in users %}
+        {% if user in users_list.staff %}
+        {{ user.username }}: is a super admin<br>
+        {% elif user in users_list.admin %}
+        {{ user.username }}: is an admin<br>
+        {% elif user in users_list.stats %}
+        {{ user.username }}: can view the Statistics page<br>
+        {% elif user in users_list.upload %}
+        {{ user.username }}: can upload new resources to the Resources page<br>
+        {% elif user in users_list.none %}
+        {{ user.username }}: does not have any special permissions<br>
+        {% endif %}
+    {% endfor %}
+
+    <div class="pagination">
+        <span class="step-links">
+            {% if users.has_previous %}
+                <a href="?page={{ users.previous_page_number }}">previous</a>
+            {% endif %}
+
+            <span class="current">
+                Page {{ users.number }} of {{ users.paginator.num_pages }}.
+            </span>
+
+            {% if users.has_next %}
+                <a href="?page={{ users.next_page_number }}">next</a>
+            {% endif %}
+        </span>
+    </div>
 
 {% block scripts %}
     <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -1,0 +1,19 @@
+{% extends 'streamwebs/base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block title %} Manage User Permissions {% endblock %}
+{% block body_title %} Manage User Permissions {% endblock %}
+
+{% block content %}
+<form id='promo_form' method='post'>
+    {% csrf_token %}
+    {{ promo_form.as_p }}
+    <input type='submit' name='submit' value='{% trans 'Apply' %}'/>
+</form>
+
+{% block scripts %}
+    <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>
+{% endblock %}
+
+{% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -6,11 +6,27 @@
 {% block body_title %} Manage User Permissions {% endblock %}
 
 {% block content %}
-<form id='promo_form' method='post'>
-    {% csrf_token %}
-    {{ promo_form.as_p }}
-    <input type='submit' name='submit' value='{% trans 'Apply' %}'/>
-</form>
+<div class="container">
+{% if messages %}
+    {% for message in messages %}
+    <strong>{{ message }}</strong>
+    {% endfor %}
+{% endif %}
+
+    <form id='promo_form' method='post'>
+        {% csrf_token %}
+        {{ promo_form.as_p }}
+        <input class="btn waves-effect waves-light teal darken-4" type='submit' name='submit' value='{% trans 'Apply' %}'/>
+    </form>
+
+    {% if users_list %}
+        {% for user, perm in users_list.items %}
+        <ul>
+            <li>{{ user }}: {{ perm }}</li>
+        </ul>
+        {% endfor %}
+    {% endif %}
+</div>
 
 {% block scripts %}
     <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -7,9 +7,9 @@
 
 {% block content %}
 <div class="container">
-{% if messages %}
-    {% for message in messages %}
-    <strong>{{ message }}</strong>
+{% if msgs %}
+    {% for message in msgs %}
+    <strong>{{ message }}</strong><br>
     {% endfor %}
 {% endif %}
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/base.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/base.html
@@ -35,13 +35,6 @@
                 </ul>
             </form>
 
-            <ul id="admin-options" class="dropdown-content">
-                <!-- TODO: Real links -->
-                <li><a href="{% url 'streamwebs:stats' %}">View Site Statistics</a></li>
-                <li><a href="{% url 'streamwebs:resources-upload' %}">Upload Resources</a></li>
-                <li><a href="#!">Manage Users</a></li>
-              </ul>
-
             <nav>
                 <div class="nav-wrapper grey lighten-5">
                     {% include "streamwebs/navigation.html" %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/navigation.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/navigation.html
@@ -20,11 +20,12 @@
 <li><a href="{% url 'streamwebs:resources' %}" class="teal-text text-darken-4">Resources</a></li>
 
 {% if user.is_authenticated %}
-    {% for group in user.groups.all %}
-        {% if group.name == 'admin' %}
-            <li><a class="teal-text text-darken-4 dropdown-button" href="#!" data-activates="admin-options">Administration<i class="material-icons right">arrow_drop_down</i></a></li>
-        {% endif %}
-    {% endfor %}
+    {% if perms.streamwebs.can_view_stats %}
+    <li><a href="{% url 'streamwebs:stats' %}" class="teal-text text-darken-4">View Site Statistics</a></li>
+    {% endif %}
+    {% if perms.streamwebs.can_promote_users %}
+    <li><a href="{% url 'streamwebs:user_promo' %}" class="teal-text text-darken-4">Manage Users</a></li>
+    {% endif %}
     <li><a href="{% url 'streamwebs:logout' %}" class="teal-text text-darken-4">Logout</a></li>
 {% else %}
     <li><a href="{% url 'streamwebs:register' %}" class="teal-text text-darken-4">Create Account</a></li>

--- a/streamwebs_frontend/streamwebs/tests/forms/test_admin_promotion_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_admin_promotion_form.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from streamwebs.forms import AdminPromotionForm
+
+
+class AdminPromotionFormTestCase(TestCase):
+    fixtures = ['sample_users.json']
+
+    def setUp(self):
+        self.expected_fields = (
+            'users',
+            'perms'
+        )
+        self.promo_form = AdminPromotionForm()
+
+    def test_form_fields_exist(self):
+        self.assertEqual(set(self.promo_form.fields),
+                         set(self.expected_fields))
+
+    def test_required_fields(self):
+        """Both fields should be required"""
+        for field in self.expected_fields:
+            self.assertEqual(self.promo_form.base_fields[field].required,
+                             True)
+
+    def test_form_isValid_with_mult_users(self):
+        user1 = User.objects.get(pk=1)
+        user2 = User.objects.get(pk=7)
+        data = {
+            'users': (user1.id, user2.id),
+            'perms': 'add_admin',
+        }
+        self.promo_form = AdminPromotionForm(data)
+        self.assertTrue(self.promo_form.is_valid())

--- a/streamwebs_frontend/streamwebs/tests/perms/test_admin_group_perms.py
+++ b/streamwebs_frontend/streamwebs/tests/perms/test_admin_group_perms.py
@@ -7,7 +7,6 @@ class AdminGroupPermissionsTestCase(TestCase):
         self.admin, self.created = Group.objects.get_or_create(name='admin')
         self.expected_perms = {
             'can upload resources',
-            'can promote other users',
             'can view site statistics',
         }
 

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -1,0 +1,72 @@
+from django.test import Client, TestCase
+from django.core.urlresolvers import reverse
+from django.core.exceptions import PermissionDenied
+from django.contrib.auth.models import User, Group, Permission
+
+
+class AdminPromoTestCase(TestCase):
+    fixtures = ['sample_users.json']
+
+    def setUp(self):
+        self.client = Client()
+        admins = Group.objects.get(name='admin')
+        can_promo = Permission.objects.get(codename='can_promote_users')
+
+        # super admin (level: Renee) with promotion permission
+        self.superAdmin = User.objects.create_user('superAdmin',
+                                                   'super@example.com',
+                                                   'superpassword')
+        self.superAdmin.groups.add(admins)
+        self.superAdmin.user_permissions.add(can_promo)
+
+        # regular admin (level: Renee's colleague) without promotion permission
+        self.regAdmin = User.objects.create_user('regAdmin', 'reg@example.com',
+                                                 'regpassword')
+        self.regAdmin.groups.add(admins)
+
+    def test_data_loaded_and_usable(self):
+        """Check users exist in test db and that admins have correct perms"""
+        self.assertEquals(User.objects.count(), 9)
+        self.assertTrue(self.superAdmin.has_perms(
+            ['streamwebs.can_view_stats', 'streamwebs.can_upload_resources',
+             'streamwebs.can_promote_users']))
+        self.assertTrue(self.regAdmin.has_perms(
+            ['streamwebs.can_view_stats', 'streamwebs.can_upload_resources']))
+        self.assertFalse(self.regAdmin.has_perm(
+            'streamwebs.can_promote_users'))
+        self.assertTrue(self.regAdmin.groups.filter(name='admin').exists())
+        self.assertTrue(self.superAdmin.groups.filter(name='admin').exists())
+
+    def test_not_logged_in_user(self):
+        """If user not logged in, can't view page, period."""
+        response = self.client.get(reverse('streamwebs:user_promo'))
+
+        self.assertRedirects(
+            response,
+            (reverse('streamwebs:login') + '?next=' +
+                reverse('streamwebs:user_promo')),
+            status_code=302,
+            target_status_code=200)
+        self.assertTemplateNotUsed(
+            response, 'streamwebs/admin/user_promo.html')
+
+    def test_superAdmin_can_view(self):
+        """Admin with promo perm should be able to view the page"""
+        self.client.login(username='superAdmin', password='superpassword')
+        response = self.client.get(reverse('streamwebs:user_promo'))
+
+        self.assertEquals(response.status_code, 200)
+        self.assertTemplateUsed(response, 'streamwebs/admin/user_promo.html')
+
+        self.client.logout()
+
+    def test_regAdmin_cannot_view(self):
+        """Admin w/o promo perm should be denied access to the page"""
+        self.client.login(username='regAdmin', password='regpassword')
+        response = self.client.get(reverse('streamwebs:user_promo'))
+
+        self.assertRaises(PermissionDenied)
+        self.assertEquals(response.status_code, 403)
+        self.assertTemplateNotUsed(response,
+                                   'streamwebs/admin/user_promo.html')
+        self.client.logout()

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -33,6 +33,15 @@ class AdminPromoTestCase(TestCase):
                                                  'regpassword')
         self.regAdmin.groups.add(self.admins)
 
+        # flash message strings
+        self.add_admin_msg = ' was added to the Admin group.'
+        self.del_admin_msg = ' was removed from the Admin group.'
+        self.add_stats_msg = ' was granted permission to view Statistics.'
+        self.del_stats_msg = ' was revoked the permission to view Statistics.'
+        self.add_upload_msg = ' was granted permission to upload resources.'
+        self.del_upload_msg = (
+            ' was revoked the permission to upload resources.')
+
     def test_data_loaded_and_usable(self):
         """Check users exist in test db and that admins have correct perms"""
         self.assertEquals(User.objects.count(), 9)
@@ -110,6 +119,13 @@ class AdminPromoTestCase(TestCase):
         self.assertContains(response,
                             str(self.user2.username) + ': ' + 'is an admin')
 
+        messages = list(response.context['msgs'])
+        self.assertEquals(len(messages), 2)
+        self.assertEquals(messages[0],
+                          self.user1.username + self.add_admin_msg)
+        self.assertEquals(messages[1],
+                          self.user2.username + self.add_admin_msg)
+
     def test_remove_users_from_admin_group(self):
         """Tests that users can be removed from the admin group"""
         self.client.login(username='superAdmin', password='superpassword')
@@ -126,6 +142,11 @@ class AdminPromoTestCase(TestCase):
         self.assertContains(response,
                             (str(self.user1.username) + ': ' +
                                 "does not have any special permissions"))
+
+        messages = list(response.context['msgs'])
+        self.assertEquals(len(messages), 1)
+        self.assertEquals(messages[0],
+                          self.user1.username + self.del_admin_msg)
 
     def test_add_stats_perm_for_users(self):
         """Tests that users can be granted the can_view_stats permission"""
@@ -148,6 +169,11 @@ class AdminPromoTestCase(TestCase):
         self.assertContains(response,
                             (str(self.user2.username) + ': ' +
                                 'can view the Statistics page'))
+
+        messages = list(response.context['msgs'])
+        self.assertEquals(len(messages), 1)
+        self.assertEquals(messages[0],
+                          self.user2.username + self.add_stats_msg)
 
     def test_remove_stats_perm_for_users(self):
         """Tests that users can have the can_view_stats permission revoked"""
@@ -186,6 +212,13 @@ class AdminPromoTestCase(TestCase):
                             (str(self.user2.username) + ': ' +
                                 'does not have any special permissions'))
 
+        messages = list(response.context['msgs'])
+        self.assertEquals(len(messages), 2)
+        self.assertEquals(messages[0],
+                          self.user1.username + self.del_stats_msg)
+        self.assertEquals(messages[1],
+                          self.user2.username + self.del_stats_msg)
+
     def test_add_upload_perm_for_users(self):
         """Tests that users can be granted the can_upload_resources perm"""
         self.client.login(username='superAdmin', password='superpassword')
@@ -204,6 +237,11 @@ class AdminPromoTestCase(TestCase):
                 response,
                 (str(self.user1.username) + ': ' +
                     'can upload new resources to the Resources page'))
+
+        messages = list(response.context['msgs'])
+        self.assertEquals(len(messages), 1)
+        self.assertEquals(messages[0],
+                          self.user1.username + self.add_upload_msg)
 
     def test_remove_upload_perm_for_users(self):
         """Tests that users can have the can_upload_stats permission revoked"""
@@ -241,3 +279,10 @@ class AdminPromoTestCase(TestCase):
         self.assertContains(response,
                             (str(self.user2.username) + ': ' +
                                 'does not have any special permissions'))
+
+        messages = list(response.context['msgs'])
+        self.assertEquals(len(messages), 2)
+        self.assertEquals(messages[0],
+                          self.user1.username + self.del_upload_msg)
+        self.assertEquals(messages[1],
+                          self.user2.username + self.del_upload_msg)

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -121,10 +121,8 @@ class AdminPromoTestCase(TestCase):
 
         messages = list(response.context['msgs'])
         self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[0],
-                          self.user1.username + self.add_admin_msg)
-        self.assertEquals(messages[1],
-                          self.user2.username + self.add_admin_msg)
+        self.assertIn(self.user1.username + self.add_admin_msg, messages)
+        self.assertIn(self.user2.username + self.add_admin_msg, messages)
 
     def test_remove_users_from_admin_group(self):
         """Tests that users can be removed from the admin group"""
@@ -214,10 +212,8 @@ class AdminPromoTestCase(TestCase):
 
         messages = list(response.context['msgs'])
         self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[0],
-                          self.user1.username + self.del_stats_msg)
-        self.assertEquals(messages[1],
-                          self.user2.username + self.del_stats_msg)
+        self.assertIn(self.user1.username + self.del_stats_msg, messages)
+        self.assertIn(self.user2.username + self.del_stats_msg, messages)
 
     def test_add_upload_perm_for_users(self):
         """Tests that users can be granted the can_upload_resources perm"""
@@ -282,7 +278,5 @@ class AdminPromoTestCase(TestCase):
 
         messages = list(response.context['msgs'])
         self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[0],
-                          self.user1.username + self.del_upload_msg)
-        self.assertEquals(messages[1],
-                          self.user2.username + self.del_upload_msg)
+        self.assertIn(self.user1.username + self.del_upload_msg, messages)
+        self.assertIn(self.user2.username + self.del_upload_msg, messages)

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -12,6 +12,9 @@ class AdminPromoTestCase(TestCase):
         admins = Group.objects.get(name='admin')
         can_promo = Permission.objects.get(codename='can_promote_users')
 
+        self.user1 = User.objects.get(pk=2)
+        self.user2 = User.objects.get(pk=7)
+
         # super admin (level: Renee) with promotion permission
         self.superAdmin = User.objects.create_user('superAdmin',
                                                    'super@example.com',
@@ -70,3 +73,87 @@ class AdminPromoTestCase(TestCase):
         self.assertTemplateNotUsed(response,
                                    'streamwebs/admin/user_promo.html')
         self.client.logout()
+
+    def test_view_with_bad_blank_data(self):
+        """If user submits bad (blank) form, form errors displayed"""
+        self.client.login(username='superAdmin', password='superpassword')
+        response = self.client.post(reverse('streamwebs:user_promo'), {})
+        self.assertFormError(response, 'promo_form', 'users',
+                             'This field is required.')
+        self.assertFormError(response, 'promo_form', 'perms',
+                             'This field is required.')
+        self.client.logout()
+
+    def test_add_users_to_admin_group(self):
+        """Tests that users can be added to the admin group"""
+        self.client.login(username='superAdmin', password='superpassword')
+
+        self.assertFalse(self.user1.groups.filter(name='admin').exists())
+        self.assertFalse(self.user2.groups.filter(name='admin').exists())
+
+        response = self.client.post(reverse('streamwebs:user_promo'), {
+            'users': (self.user1.id, self.user2.id),
+            'perms': 'add_admin',
+            }
+        )
+        self.assertTrue(self.user1.groups.filter(name='admin').exists())
+        self.assertTrue(self.user2.groups.filter(name='admin').exists())
+
+    def test_remove_users_from_admin_group(self):
+        """Tests that users can be removed from the admin group"""
+        self.client.login(username='superAdmin', password='superpassword')
+
+        response = self.client.post(reverse('streamwebs:user_promo'), {
+            'users': (self.user1.id),
+            'perms': 'del_admin',
+            }
+        )
+        self.assertFalse(self.user1.groups.filter(name='admin').exists())
+
+    def test_add_stats_perm_for_users(self):
+        """Tests that users can be granted the can_view_stats permission"""
+        self.client.login(username='superAdmin', password='superpassword')
+
+        response = self.client.post(reverse('streamwebs:user_promo'), {
+            'users': (self.user1.id),
+            'perms': 'add_stats',
+            }
+        )
+        self.assertTrue(self.user1.has_perm('streamwebs.can_view_stats'))
+
+    def test_remove_stats_perm_for_users(self):
+        """Tests that users can have the can_view_stats permission revoked"""
+        self.client.login(username='superAdmin', password='superpassword')
+
+        response = self.client.post(reverse('streamwebs:user_promo'), {
+            'users': (self.user1.id, self.user2.id),
+            'perms': 'del_stats',
+            }
+        )
+        self.assertFalse(self.user1.has_perm('streamwebs.can_view_stats'))
+        self.assertFalse(self.user2.has_perm('streamwebs.can_view_stats'))
+
+    def test_add_upload_perm_for_users(self):
+        """Tests that users can be granted the can_upload_resources perm"""
+        self.client.login(username='superAdmin', password='superpassword')
+
+        response = self.client.post(reverse('streamwebs:user_promo'), {
+            'users': (self.user1.id),
+            'perms': 'add_upload',
+            }
+        )
+        self.assertTrue(self.user1.has_perm('streamwebs.can_upload_resources'))
+
+    def test_remove_upload_perm_for_users(self):
+        """Tests that users can have the can_upload_stats permission revoked"""
+        self.client.login(username='superAdmin', password='superpassword')
+
+        response = self.client.post(reverse('streamwebs:user_promo'), {
+            'users': (self.user1.id, self.user2.id),
+            'perms': 'del_upload',
+            }
+        )
+        self.assertFalse(self.user1.has_perm(
+            'streamwebs.can_upload_resources'))
+        self.assertFalse(self.user2.has_perm(
+            'streamwebs.can_upload_resources'))

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -121,22 +121,6 @@ class AdminPromoTestCase(TestCase):
         self.assertIn(self.user1.username + self.add_admin_msg, messages)
         self.assertIn(self.user2.username + self.add_admin_msg, messages)
 
-        done1 = False
-        done2 = False
-        for i in range(1, self.pages + 1):
-            if self.user1 in response.context['users']:
-                self.assertContains(
-                    response, str(self.user1.username + ': ' + 'is an admin'))
-                done1 = True
-            if self.user2 in response.context['users']:
-                self.assertContains(
-                    response, str(self.user2.username + ': ' + 'is an admin'))
-                done2 = True
-            response = self.client.get(
-                reverse('streamwebs:user_promo') + '?page=' + str(i+1))
-        if done1 is False or done2 is False:
-            raise ValueError("didn't find user1 or user2")
-
     def test_remove_users_from_admin_group(self):
         """Tests that users can be removed from the admin group"""
         self.client.login(username='superAdmin', password='superpassword')
@@ -155,26 +139,6 @@ class AdminPromoTestCase(TestCase):
         self.assertEquals(len(messages), 1)
         self.assertEquals(messages[0],
                           self.user1.username + self.del_admin_msg)
-
-        done1 = False
-        done2 = False
-        for i in range(1, self.pages + 1):
-            if self.user1 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user1.username + ': ' +
-                        'does not have any special permissions'))
-                done1 = True
-            if self.user2 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user2.username + ': ' +
-                        'does not have any special permissions'))
-                done2 = True
-            response = self.client.get(
-                reverse('streamwebs:user_promo') + '?page=' + str(i+1))
-        if done1 is False or done2 is False:
-            raise ValueError("didn't find user1 or user2")
 
     def test_add_stats_perm_for_users(self):
         """Tests that users can be granted the can_view_stats permission"""
@@ -198,18 +162,6 @@ class AdminPromoTestCase(TestCase):
         self.assertEquals(len(messages), 1)
         self.assertEquals(messages[0],
                           self.user2.username + self.add_stats_msg)
-        done1 = False
-        for i in range(1, self.pages + 1):
-            if self.user2 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user2.username + ': ' +
-                        'can view the Statistics page'))
-                done1 = True
-            response = self.client.get(
-                reverse('streamwebs:user_promo') + '?page=' + str(i+1))
-        if done1 is False:
-            raise ValueError("didn't find user2")
 
     def test_remove_stats_perm_for_users(self):
         """Tests that users can have the can_view_stats permission revoked"""
@@ -245,26 +197,6 @@ class AdminPromoTestCase(TestCase):
         self.assertIn(self.user1.username + self.del_stats_msg, messages)
         self.assertIn(self.user2.username + self.del_stats_msg, messages)
 
-        done1 = False
-        done2 = False
-        for i in range(1, self.pages + 1):
-            if self.user1 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user1.username + ': ' +
-                        'can upload new resources to the Resources page'))
-                done1 = True
-            if self.user2 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user2.username + ': ' +
-                        'does not have any special permissions'))
-                done2 = True
-            response = self.client.get(
-                reverse('streamwebs:user_promo') + '?page=' + str(i+1))
-        if done1 is False or done2 is False:
-            raise ValueError("didn't find user1 or user2")
-
     def test_add_upload_perm_for_users(self):
         """Tests that users can be granted the can_upload_resources perm"""
         self.client.login(username='superAdmin', password='superpassword')
@@ -283,19 +215,6 @@ class AdminPromoTestCase(TestCase):
         self.assertEquals(len(messages), 1)
         self.assertEquals(messages[0],
                           self.user1.username + self.add_upload_msg)
-
-        done1 = False
-        for i in range(1, self.pages + 1):
-            if self.user1 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user1.username + ': ' +
-                        'can upload new resources to the Resources page'))
-                done1 = True
-            response = self.client.get(
-                reverse('streamwebs:user_promo') + '?page=' + str(i+1))
-        if done1 is False:
-            raise ValueError("didn't find user1")
 
     def test_remove_upload_perm_for_users(self):
         """Tests that users can have the can_upload_stats permission revoked"""
@@ -331,23 +250,3 @@ class AdminPromoTestCase(TestCase):
         self.assertEquals(len(messages), 2)
         self.assertIn(self.user1.username + self.del_upload_msg, messages)
         self.assertIn(self.user2.username + self.del_upload_msg, messages)
-
-        done1 = False
-        done2 = False
-        for i in range(1, self.pages + 1):
-            if self.user1 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user1.username + ': ' +
-                        'can view the Statistics page'))
-                done1 = True
-            if self.user2 in response.context['users']:
-                self.assertContains(
-                    response,
-                    str(self.user2.username + ': ' +
-                        'does not have any special permissions'))
-                done2 = True
-            response = self.client.get(
-                reverse('streamwebs:user_promo') + '?page=' + str(i+1))
-        if done1 is False or done2 is False:
-            raise ValueError("didn't find user1 or user2")

--- a/streamwebs_frontend/streamwebs/tests/views/test_resource_upload.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_resource_upload.py
@@ -35,11 +35,7 @@ class UploadResourceTestCase(TestCase):
 
     def test_not_logged_in_user(self):
         """If user is not logged in, can't view the upload page or link"""
-        # grab resources view: can't see link
-        response = self.client.get(reverse('streamwebs:resources'))
-        self.assertEquals(response.status_code, 200)
-        self.assertNotContains(response, 'Upload a new resource')
-        # grab resources upload: redirected to login
+        # Can't access upload page:
         response = self.client.get(reverse('streamwebs:resources-upload'))
         self.assertRedirects(
             response,
@@ -50,7 +46,7 @@ class UploadResourceTestCase(TestCase):
         self.assertTemplateNotUsed(
             response, 'streamwebs/resources/resources-upload.html')
 
-        """Should not be able to view link in resources.html"""
+        # Can't view link on resources page:
         response = self.client.get(reverse('streamwebs:resources'))
         self.assertContains(
             response,
@@ -65,7 +61,7 @@ class UploadResourceTestCase(TestCase):
             ['streamwebs.can_upload_resources', 'streamwebs.can_view_stats']))
         self.assertTrue(self.admin.groups.filter(name='admin').exists())
         response = self.client.get(reverse('streamwebs:resources-upload'))
-        self.assertTrue(response.status_code, 200)
+        self.assertEquals(response.status_code, 200)
         self.assertTemplateUsed(
             response, 'streamwebs/resources/resources_upload.html')
         self.assertContains(response, 'Upload a new resource')
@@ -89,7 +85,7 @@ class UploadResourceTestCase(TestCase):
             self.special_user.groups.filter(name='admin').exists())
         self.client.login(username='special_user', password='specialpassword')
         response = self.client.get(reverse('streamwebs:resources-upload'))
-        self.assertTrue(response.status_code, 200)
+        self.assertEquals(response.status_code, 200)
         self.assertTemplateUsed(
             response, 'streamwebs/resources/resources_upload.html')
         self.assertContains(response, 'Upload a new resource')

--- a/streamwebs_frontend/streamwebs/tests/views/test_resource_upload.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_resource_upload.py
@@ -23,7 +23,7 @@ class UploadResourceTestCase(TestCase):
         can_upload = Permission.objects.get(codename='can_upload_resources')
         self.special_user.user_permissions.add(can_upload)
 
-        # admin user with all permissions
+        # admin user with admin permissions (stats and resources)
         admins = Group.objects.get(name='admin')
         self.admin = User.objects.create_user('admin', 'admin@example.com',
                                               'adminpassword')
@@ -62,8 +62,7 @@ class UploadResourceTestCase(TestCase):
         """User in admin group with upload perm should be able to view page"""
         self.client.login(username='admin', password='adminpassword')
         self.assertTrue(self.admin.has_perms(
-            ['streamwebs.can_upload_resources', 'streamwebs.can_promote_users',
-             'streamwebs.can_view_stats']))
+            ['streamwebs.can_upload_resources', 'streamwebs.can_view_stats']))
         self.assertTrue(self.admin.groups.filter(name='admin').exists())
         response = self.client.get(reverse('streamwebs:resources-upload'))
         self.assertTrue(response.status_code, 200)

--- a/streamwebs_frontend/streamwebs/tests/views/test_stats_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_stats_view.py
@@ -23,7 +23,7 @@ class AdminStatsTestCase(TestCase):
                                                      'special@example.com',
                                                      'specialpassword')
         admins = Group.objects.get(name='admin')
-        # admin user with all permissions
+        # admin user with admin permissions (stats and resources)
         self.admin = User.objects.create_user('admin', 'admin@example.com',
                                               'adminpassword')
         self.admin.groups.add(admins)    # add test admin user to group
@@ -103,8 +103,8 @@ class AdminStatsTestCase(TestCase):
         # default admin
         admin = User.objects.get(username="admin")
         self.assertTrue(admin.has_perms(['streamwebs.can_view_stats',
-                                         'streamwebs.can_upload_resources',
-                                         'streamwebs.can_promote_users']))
+                                         'streamwebs.can_upload_resources']))
+        self.assertFalse(admin.has_perm('streamwebs.can_promote_users'))
 
         # regular user
         reg_user = User.objects.get(username='reg_user')

--- a/streamwebs_frontend/streamwebs/urls.py
+++ b/streamwebs_frontend/streamwebs/urls.py
@@ -85,6 +85,8 @@ urlpatterns = [
         views.export_soil, name='export_soil'),
 
     url(r'^statistics/$', views.admin_site_statistics, name='stats'),
+    url(r'^user-promotion/$', views.admin_user_promotion, name='user_promo'),
+
     url(r'^register/$', views.register, name='register'),
     url(r'^login/$', views.user_login, name='login'),
     url(r'^logout/$', views.user_logout, name='logout'),

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -18,7 +18,7 @@ from streamwebs.forms import (
     PhotoPointImageForm, PhotoPointForm, CameraPointForm, WQSampleForm,
     WQSampleFormReadOnly, WQForm, WQFormReadOnly, SiteForm, Canopy_Cover_Form,
     SoilSurveyForm, SoilSurveyFormReadOnly, StatisticsForm, TransectZoneForm,
-    BaseZoneInlineFormSet, ResourceForm)
+    BaseZoneInlineFormSet, ResourceForm, AdminPromotionForm)
 
 from streamwebs.models import (
     Macroinvertebrates, Site, Water_Quality, WQ_Sample, RiparianTransect,
@@ -979,5 +979,17 @@ def resources_upload(request):
     return render(
         request, 'streamwebs/resources/resources_upload.html', {
             'res_form': res_form,
+        }
+    )
+
+
+@login_required
+@permission_required('streamwebs.can_promote_users', raise_exception=True)
+def admin_user_promotion(request):
+    promo_form = AdminPromotionForm()
+
+    return render(
+        request, 'streamwebs/admin/user_promo.html', {
+            'promo_form': promo_form,
         }
     )

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -986,7 +986,9 @@ def resources_upload(request):
 @login_required
 @permission_required('streamwebs.can_promote_users', raise_exception=True)
 def admin_user_promotion(request):
+    users_list = dict()
     admins = Group.objects.get(name='admin')
+    admin_perms = Permission.objects.filter(group=admins)
     can_view_stats = Permission.objects.get(codename='can_view_stats')
     can_upload_resources = Permission.objects.get(
         codename='can_upload_resources')
@@ -1030,7 +1032,6 @@ def admin_user_promotion(request):
                 elif action == 'del_upload':
                     if user.groups.filter(name='admin').exists():
                         user.groups.remove(admins)
-                        admin_perms = Permission.objects.filter(group=admins)
                         for perm in admin_perms:
                             if perm.codename != 'can_upload_resources':
                                 user.user_permissions.add(perm)
@@ -1041,8 +1042,22 @@ def admin_user_promotion(request):
             # and how (add all modified users to a list and pass to template)
             # check if user already has requested perms via form cleaning?
 
+    all_users = User.objects.all()
+    for user in all_users:
+        if user.is_staff:
+            users_list[user] = 'is a super admin'
+        elif user.groups.filter(name='admin').exists():
+            users_list[user] = 'is an admin'
+        elif user.has_perm('streamwebs.can_view_stats'):
+            users_list[user] = 'can view the Statistics page'
+        elif user.has_perm('streamwebs.can_upload_resources'):
+            users_list[user] = 'can upload new resources to the Resources page'
+        else:
+            users_list[user] = 'does not have any special permissions'
+
     return render(
         request, 'streamwebs/admin/user_promo.html', {
             'promo_form': promo_form,
+            'users_list': users_list,
         }
     )

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -1091,5 +1091,6 @@ def admin_user_promotion(request):
             'users': users,
             'users_list': users_list,
             'msgs': msgs,
+            'all_users': all_users,
         }
     )

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -992,6 +992,7 @@ def admin_user_promotion(request):
     can_view_stats = Permission.objects.get(codename='can_view_stats')
     can_upload_resources = Permission.objects.get(
         codename='can_upload_resources')
+    msgs = []    # list to hold custom flash messages
 
     promo_form = AdminPromotionForm()
 
@@ -1005,12 +1006,19 @@ def admin_user_promotion(request):
             for user in users:
                 if action == 'add_admin':
                     user.groups.add(admins)
+                    msgs.append(
+                        '%s was added to the Admin group.' % user.username)
 
                 elif action == 'del_admin':
                     user.groups.remove(admins)
+                    msgs.append(
+                        '%s was removed from the Admin group.' % user.username)
 
                 elif action == 'add_stats':
                     user.user_permissions.add(can_view_stats)
+                    msgs.append(
+                        '%s was granted permission to view Statistics.'
+                        % user.username)
 
                 elif action == 'del_stats':
                     # if they're an admin,
@@ -1022,12 +1030,19 @@ def admin_user_promotion(request):
                         for perm in admin_perms:
                             if perm.codename != 'can_view_stats':
                                 user.user_permissions.add(perm)
-                    # if they're a regular user,
+                    # otherwise if they're a regular user,
                     else:
                         user.user_permissions.remove(can_view_stats)
 
+                    msgs.append(
+                        '%s was revoked the permission to view Statistics.'
+                        % user.username)
+
                 elif action == 'add_upload':
                     user.user_permissions.add(can_upload_resources)
+                    msgs.append(
+                        '%s was granted permission to upload resources.'
+                        % user.username)
 
                 elif action == 'del_upload':
                     if user.groups.filter(name='admin').exists():
@@ -1038,9 +1053,9 @@ def admin_user_promotion(request):
                     else:
                         user.user_permissions.remove(can_upload_resources)
 
-            # flash a success message that includes which users were changed
-            # and how (add all modified users to a list and pass to template)
-            # check if user already has requested perms via form cleaning?
+                    msgs.append(
+                        '%s was revoked the permission to upload resources.'
+                        % user.username)
 
     all_users = User.objects.all()
     for user in all_users:
@@ -1059,5 +1074,6 @@ def admin_user_promotion(request):
         request, 'streamwebs/admin/user_promo.html', {
             'promo_form': promo_form,
             'users_list': users_list,
+            'msgs': msgs,
         }
     )


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #242 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

This view:
- [X] can add/remove permissions for other users
- [X] is restricted to "super" admins that have the "promotion" permission, i.e. django superusers and Renee
- [x] flashes a message upon successful updates that includes which users were changed and how
- [x] displays a list of all users and their current permissions/groups (now with pagination)

further TODO:
- [ ] Default user should be ------ instead of the first user in the list-- will be addressed in a new PR/issue if addressed at all
- [x] Add a link to the view from the nav bar 

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. run tests: ``docker-compose run web bash`` and ``cd streamwebs_frontend`` ``python manage.py test streamwebs/tests*``
2. Make sure your migrations current and have been applied. I usually nuke 0001 and remake it to do this.
3. Create a superuser: ``python manage.py createsuperuser``
4. Load in test users if not already present: ``cd ../data_scripts`` and ``./get_schools.py`` and ``./get_users.py``
5. ``docker-compose up`` and go to http://localhost:8000/user-promotion/
6. Go wild
7. Try logging in as a user you have changed and verify that you can/can't perform the relevant actions, like viewing the stats page or the upload resources page
8. Also verify that viewing the user promotion page is impossible if you're not logged in/not logged in as a superuser or a user that has the can_promote_users permission
9. To test pagination: you can decrease the number of users shown per page by changing the number on line 1056 in ``views/general.py``

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
[root@74b9b8eaea62 streamwebs_frontend]# python manage.py test streamwebs/tests/*
Creating test database for alias 'default'...
admin group created; permissions added
System check identified no issues (0 silenced).
.....................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 229 tests in 13.051s

OK
Destroying test database for alias 'default'...

```
![perms](https://cloud.githubusercontent.com/assets/9158473/26322404/cc254bd4-3edf-11e7-9640-72e9ccfab138.png)

