### PR TITLE
Prettify admin

### DIFF
--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -253,12 +253,12 @@ class ResourceForm(forms.ModelForm):
 
 class StatisticsForm(forms.Form):
     start = forms.DateField(
-        widget=forms.DateInput(attrs={'class': 'datepicker'}),
-        label=_('starting from'), required=False
+        widget=forms.DateInput(attrs={'class': 'datepicker col s5'}),
+        label=_('Starting from'), required=False
     )
     end = forms.DateField(
-        widget=forms.DateInput(attrs={'class': 'datepicker'}),
-        label=_('ending on'), required=False
+        widget=forms.DateInput(attrs={'class': 'datepicker col s5'}),
+        label=_('Ending on'), required=False
     )
 
 

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -272,6 +272,8 @@ class AdminPromotionForm(forms.Form):
         ('del_upload', _('Revoke permission to upload to the Resources page')),
     )
 
-    users = forms.ModelMultipleChoiceField(queryset=User.objects.all(),
-                                           widget=forms.SelectMultiple)
+    users_display = forms.CharField(max_length=100)
+
+    users = forms.ModelChoiceField(queryset=User.objects.all(),
+                                   widget=forms.HiddenInput())
     perms = forms.ChoiceField(choices=PERM_OPTIONS)

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/admin/stats.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/admin/stats.js
@@ -1,0 +1,87 @@
+/***************************************************
+        Adjust the card size
+        Associated with: ajustCardHeight, getHeight
+***************************************************/
+var adjustCardSize = function adjustCardSize() {
+    var countDivs = $('div.count-row > div');
+    if ($(window).width() < 880) {
+        if (countDivs.hasClass("s6")) {
+            countDivs.removeClass("s6").addClass("s12");
+        }
+        adjustCardHeight(false);
+    }
+    else {
+        if (countDivs.hasClass("s12")) {
+            countDivs.removeClass("s12").addClass("s6");
+        }
+        adjustCardHeight(true);
+    }
+}
+
+var adjustCardHeight = function adjustCardHeight(matchHeight) {
+    if (matchHeight) {
+        $('div.count-row').each(function() {
+
+            var countDivs = $(this).find('div.card');
+            var height0 = getHeight(countDivs[0]);
+            var height1 = getHeight(countDivs[1]);
+            var height = Math.max(height0, height1);
+
+            countDivs.each(function() {
+                $(this).height(height);
+            })
+        });
+    } else {
+        $('div.count').each(function() {
+            var height = getHeight(this);
+            $(this).height(getHeight(this));
+        });
+    }
+}
+
+var getHeight = function getHeight(elem) {
+    height = 0;
+    $(elem).children().each(function() {
+        height += $(this).height();
+    });
+    return height + 45;
+}
+/***************************************************
+        Document ready & Document related
+***************************************************/
+
+$(document).ready(function() {
+    adjustCardSize();
+    $('#schools_table').DataTable({
+        bLengthChange: false,
+        "pageLength": 13
+    });
+    $('#sites_table').DataTable({
+        bLengthChange: false,
+        "pageLength": 13
+    })
+    $('.datepicker').pickadate({
+        today: '',
+        selectMonths: true, // Creates a dropdown to control month
+        selectYears: 100, // Creates a dropdown of 15 years to control year
+        max: true, // set max to today
+        format: 'yyyy-mm-dd',
+    });
+
+    $('input#schools-btn').click(function() {
+        $('div.count-row').hide();
+        $('div.schools').show();
+    });
+    $('input#sites-btn').click(function() {
+        $('div.count-row').hide();
+        $('div.sites').show();
+    });
+    $('input.back').click(function() {
+        $('div.schools, div.sites').hide();
+        $('div.count-row').show();
+    })
+});
+
+$(window).resize(function () {
+    adjustCardSize();
+})

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/stats.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/stats.html
@@ -6,34 +6,89 @@
 {% block body_title %} StreamWebs Statistics {% endblock %}
 
 {% block content %}
-<form id='stats_form' method='post'>
-    {% csrf_token %}
-    {{ stats_form.as_p }}
-    <input type='submit' name='submit' value='{% trans 'Calculate' %}'/>
-</form>
+<div class="container">
+  <form id='stats_form' method='post'>
+      {% csrf_token %}
+      {{ stats_form.as_p }}
+      <input type='submit' name='submit' value='{% trans 'Calculate' %}'/>
+  </form>
+  <br>
+  <div class="row">
+    <div class="col s4">
+      <div class="card teal darken-4">
+        <div class="card-content white-text">
+          {% if all_time %}
+            <span class="card-title">{{ users.count }}</span>
+            <p>Users have logged in within the last 3 years</p>
+          {% else %}
+            <span class="card-title">{{ users.count }}</span>
+            <p>Users who joined between {{ start }} and {{ end }}</p>
+          {% endif %}
 
-{% if all_time %}
-Users who have logged in within the last 3 years: {{ users.count }}
-{% else %}
-Users who joined between {{ start }} and {{ end }}: {{ users.count }}
-{% endif %}
-{% for user in users.users %}
-    <li>{{ user.username }}</li>
-{% endfor %}
+        </div>
+      </div>
 
-Number of data sheets uploaded between {{ start }} and {{ end }}:
-{% for type, num in sheets.items %}
-<li> {{ type }}: {{ num }}</li>
-{% endfor %}
+    </div>
 
-Schools that uploaded data between {{ start }} and {{ end }}: {{ schools.total }}
-{% for school in schools.schools %}
-<li> {{ school.name }} </li>
-{% endfor %}
+    <div class="col s4">
+      <div class="card teal darken-4">
+        <div class="card-content white-text">
+          <span class="card-title">{{ sheets.total }}</span>
+          <p>
+            Data sheets uploaded between {{ start }} and {{ end }}
+            <ul>
+              {% for type, num in sheets.items %}
+                <li> {{ type }}: {{ num }}</li>
+              {% endfor %}
+            </ul>
+          </p>
+        </div>
+      </div>
+    </div>
 
-Sites that uploaded data between {{ start }} and {{ end }}: {{ sites.total }}
-{% for site in sites.sites %}
-<li>{{ site.site_name }}</li>
-{% endfor %}
+    <div class="col s4">
+      <div class="card teal darken-4">
+        <div class="card-content white-text">
+          <span class="card-title"> {{ schools.total }} </span>
+            <p>
+              Schools that uploaded data between {{ start }} and {{ end }}
+              <ul>
+                {% for school in schools.schools %}
+                <li> {{ school.name }} </li>
+                {% endfor %}
+              </ul>
+          </p>
+        </div>
+      </div>
+    </div>
 
+    <div class="col s12">
+      <div class="card teal darken-4">
+        <div class="card-content white-text">
+          <span class="card-title"> {{ sites.total }} </span>
+          <h6>Sites that uploaded data between {{ start }} and {{ end }}</h6>
+          <p>
+            {% for site in sites.sites %}
+              <li>{{ site.site_name }}</li>
+            {% endfor %}
+          </p>
+        </div>
+      </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+$(document).ready(function() {
+  $('.datepicker').pickadate({
+    today: '',
+    selectMonths: true, // Creates a dropdown to control month
+    selectYears: 100, // Creates a dropdown of 15 years to control year
+    max: true, // set max to today
+    format: 'yyyy-mm-dd',
+  });
+});
+
+
+</script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/stats.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/stats.html
@@ -2,93 +2,132 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block title %} StreamWebs Statistics {% endblock %}
-{% block body_title %} StreamWebs Statistics {% endblock %}
+{% block title %}{% trans "StreamWebs Statistics" %}{% endblock %}
+{% block body_title %}{% trans "StreamWebs Statistics" %}{% endblock %}
+{% block head %}
+<link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.15/css/jquery.dataTables.min.css">
 
+{% endblock %}
 {% block content %}
-<div class="container">
-  <form id='stats_form' method='post'>
-      {% csrf_token %}
-      {{ stats_form.as_p }}
-      <input type='submit' name='submit' value='{% trans 'Calculate' %}'/>
-  </form>
-  <br>
-  <div class="row">
-    <div class="col s4">
-      <div class="card teal darken-4">
-        <div class="card-content white-text">
-          {% if all_time %}
-            <span class="card-title">{{ users.count }}</span>
-            <p>Users have logged in within the last 3 years</p>
-          {% else %}
-            <span class="card-title">{{ users.count }}</span>
-            <p>Users who joined between {{ start }} and {{ end }}</p>
-          {% endif %}
-
+  <div class="container">
+    <form id='stats_form' method='post'>
+        {% csrf_token %}
+        {{ stats_form.as_p }}
+        <input class="btn waves-effect teal darken-4" type='submit' name='submit'
+          value='{% trans 'Calculate' %}'/>
+    </form>
+    <br>
+    <div class="row count-row">
+      <div class="col s6 count">
+        <div class="card teal darken-4">
+          <div class="card-content white-text">
+            {% if all_time %}
+              <span class="card-title">{{ users.count }}</span>
+              <p>
+                Users have logged in within the last 3 years
+              </p>
+            {% else %}
+              <span class="card-title">{{ users.count }}</span>
+              <p>
+                Users who joined between {{ start }} and {{ end }}
+              </p>
+            {% endif %}
+          </div>
         </div>
       </div>
 
-    </div>
-
-    <div class="col s4">
-      <div class="card teal darken-4">
-        <div class="card-content white-text">
-          <span class="card-title">{{ sheets.total }}</span>
-          <p>
-            Data sheets uploaded between {{ start }} and {{ end }}
-            <ul>
+      <div class="col s6 count">
+        <div class="card teal darken-4">
+          <div class="card-content white-text">
+            <span class="card-title">{{ sheets.total }}</span>
+            <p>
+              Data sheets uploaded between {{ start }} and {{ end }}
+            </p>
+            <br>
+            <p>
               {% for type, num in sheets.items %}
                 <li> {{ type }}: {{ num }}</li>
               {% endfor %}
-            </ul>
-          </p>
+            </p>
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="col s4">
-      <div class="card teal darken-4">
-        <div class="card-content white-text">
-          <span class="card-title"> {{ schools.total }} </span>
+    <div class="row count-row">
+      <div class="col s6 count">
+        <div class="card teal darken-4">
+          <div class="card-content white-text">
+            <span class="card-title"> {{ schools.total }} </span>
             <p>
               Schools that uploaded data between {{ start }} and {{ end }}
-              <ul>
-                {% for school in schools.schools %}
-                <li> {{ school.name }} </li>
-                {% endfor %}
-              </ul>
-          </p>
+            </p>
+            <br>
+            <input type="button" value="View All Schools"
+              id = "schools-btn" class="btn teal darken-3"/>
+          </div>
+        </div>
+      </div>
+
+      <div class="col s6 count">
+        <div class="card teal darken-4">
+          <div class="card-content white-text">
+            <span class="card-title"> {{ sites.total }} </span>
+            <p>
+              Sites that uploaded data between {{ start }} and {{ end }}
+            </p>
+            <br>
+            <input type="button" value="View All Sites" style="margin: 0 auto;"
+              id="sites-btn" class="btn teal darken-3"/>
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="col s12">
-      <div class="card teal darken-4">
-        <div class="card-content white-text">
-          <span class="card-title"> {{ sites.total }} </span>
-          <h6>Sites that uploaded data between {{ start }} and {{ end }}</h6>
-          <p>
-            {% for site in sites.sites %}
-              <li>{{ site.site_name }}</li>
-            {% endfor %}
-          </p>
-        </div>
-      </div>
-</div>
+    <div class="row schools" style="display:none;">
+      <input type="button" value="Back" class="back btn teal darken-3"/>
+      <table id="schools_table">
+        <thead>
+          <tr>
+            <th>School</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for school in schools.schools %}
+            <tr>
+              <td>
+                {{ school.name }}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="row sites" style="display:none;">
+      <input type="button" value="Back" class="back btn teal darken-3 s12 l4"/>
+      <table id="sites_table">
+        <thead>
+          <tr>
+            <th>Sites</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for site in sites.sites %}
+            <tr>
+              <td>
+                {{ site.site_name }}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
 {% endblock %}
 
 {% block scripts %}
-<script>
-$(document).ready(function() {
-  $('.datepicker').pickadate({
-    today: '',
-    selectMonths: true, // Creates a dropdown to control month
-    selectYears: 100, // Creates a dropdown of 15 years to control year
-    max: true, // set max to today
-    format: 'yyyy-mm-dd',
-  });
-});
-
-
-</script>
+  <script src="//cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"></script>
+  <script type="application/javascript"
+          src="{% static 'streamwebs/js/admin/stats.js' %}"></script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -5,6 +5,7 @@
 {% block title %} Manage User Permissions {% endblock %}
 {% block body_title %} Manage User Permissions {% endblock %}
 
+
 {% block content %}
 <div class="container">
 {% if msgs %}
@@ -48,9 +49,23 @@
       {% endif %}
     </span>
   </div>
-
+{% endblock %}
 {% block scripts %}
-  <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>
+  <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('select').material_select();
+      $( "#id_users_display" ).autocomplete({
+        source: "{% url 'streamwebs:users_auto_complete' %}",
+        select: function(event, ui) {
+          $( "#id_users" ).val(ui.item.id)
+        }
+      });
+    });
+  </script>
 {% endblock %}
 
-{% endblock %}
+

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -53,11 +53,11 @@
 {% block scripts %}
   <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+  <!--  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script> -->
 
   <script type="text/javascript">
     $(document).ready(function() {
-      $('select').material_select();
+    //  $('select').material_select();
       $( "#id_users_display" ).autocomplete({
         source: "{% url 'streamwebs:users_auto_complete' %}",
         select: function(event, ui) {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_promo.html
@@ -51,21 +51,38 @@
   </div>
 {% endblock %}
 {% block scripts %}
+
   <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
   <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-  <!--  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script> -->
-
+  <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script> -->
   <script type="text/javascript">
+
     $(document).ready(function() {
-    //  $('select').material_select();
-      $( "#id_users_display" ).autocomplete({
-        source: "{% url 'streamwebs:users_auto_complete' %}",
-        select: function(event, ui) {
-          $( "#id_users" ).val(ui.item.id)
-        }
-      });
+
+      // materialize css select
+      $('select').material_select();
+      // console.log({% url 'streamwebs:users_auto_complete' %})
+      // var users_list=[];
+      // // get ajax of list of users
+      // $.ajax({
+      //   url: {% url 'streamwebs:users_auto_complete' %},
+      //   dataType: "json",
+      //   cache: false,
+      //   success:function(data){
+      //     console.log(data)
+      //     users_list = data;
+      //     // jquery autocomplete
+      //     $( "#id_users_display" ).autocomplete({
+      //       source: users_list,
+      //       select: function(event, ui) {
+      //         $( "#id_users" ).val(ui.item.id)
+      //       }
+      //     });
+      //   }
+      // });
+      // console.log("outside ajax")
+      // console.log(users_list)
+
     });
   </script>
 {% endblock %}
-
-

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_status.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/user_status.html
@@ -1,0 +1,58 @@
+{% extends 'streamwebs/base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block title %} Manage User Permissions {% endblock %}
+{% block body_title %} Manage User Permissions {% endblock %}
+{% block head %}
+<link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.15/css/jquery.dataTables.min.css">
+
+{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <table id="users_table">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Admin</th>
+          <th>Email</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user in users %}
+          <tr>
+            <td>
+              <a href="{% url 'streamwebs:user_promotion' user.username %}">
+                {{ user.username }}
+              </a>
+            </td>
+            <td style="text-align:center">
+              {% if user_status.user %}
+                Yes
+              {% else %}
+                No
+              {% endif %}
+            </td>
+            <td>
+              {{ user.email }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+  <script src="//cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"></script>
+  <script>
+    $(document).ready(function() {
+      $('#users_table').DataTable({
+        "bLengthChange": false,
+        "pageLength": 20,
+      });
+    });
+  </script>
+{% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/base.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/base.html
@@ -5,6 +5,7 @@
 <head>
     <meta charset="utf-8" />
     <title>{% block title %}Streamwebs{% endblock %}</title>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link rel="stylesheet" type="text/css" href="{% static 'streamwebs/bower_components/materialize/dist/css/materialize.css' %}" />
     <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{% static 'streamwebs/style.css' %}" />

--- a/streamwebs_frontend/streamwebs/tests/forms/test_admin_promotion_form.py
+++ b/streamwebs_frontend/streamwebs/tests/forms/test_admin_promotion_form.py
@@ -8,6 +8,7 @@ class AdminPromotionFormTestCase(TestCase):
 
     def setUp(self):
         self.expected_fields = (
+            'users_display',
             'users',
             'perms'
         )
@@ -18,16 +19,16 @@ class AdminPromotionFormTestCase(TestCase):
                          set(self.expected_fields))
 
     def test_required_fields(self):
-        """Both fields should be required"""
+        """All fields should be required"""
         for field in self.expected_fields:
             self.assertEqual(self.promo_form.base_fields[field].required,
                              True)
 
     def test_form_isValid_with_mult_users(self):
         user1 = User.objects.get(pk=1)
-        user2 = User.objects.get(pk=7)
         data = {
-            'users': (user1.id, user2.id),
+            'users_display': user1.username,
+            'users': user1.id,
             'perms': 'add_admin',
         }
         self.promo_form = AdminPromotionForm(data)

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -179,7 +179,7 @@ class AdminPromoTestCase(TestCase):
             }
         )
         # user2 should be a regular user now w/o the stats perm.
-        self.user2 = User.objects.get(pk=7)     #re-query: perms are cached
+        self.user2 = User.objects.get(pk=7)     # re-query: perms are cached
 
         self.assertFalse(self.user2.groups.filter(name='admin').exists())
 

--- a/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
+++ b/streamwebs_frontend/streamwebs/tests/views/test_admin_promo_view.py
@@ -106,20 +106,17 @@ class AdminPromoTestCase(TestCase):
         self.client.login(username='superAdmin', password='superpassword')
 
         self.assertFalse(self.user1.groups.filter(name='admin').exists())
-        self.assertFalse(self.user2.groups.filter(name='admin').exists())
 
         response = self.client.post(reverse('streamwebs:user_promo'), {
-            'users': (self.user1.id, self.user2.id),
+            'users_display': self.user1.username,
+            'users': self.user1.id,
             'perms': 'add_admin',
             }
         )
         self.assertTrue(self.user1.groups.filter(name='admin').exists())
-        self.assertTrue(self.user2.groups.filter(name='admin').exists())
 
         messages = list(response.context['msgs'])
-        self.assertEquals(len(messages), 2)
         self.assertIn(self.user1.username + self.add_admin_msg, messages)
-        self.assertIn(self.user2.username + self.add_admin_msg, messages)
 
     def test_remove_users_from_admin_group(self):
         """Tests that users can be removed from the admin group"""
@@ -129,7 +126,8 @@ class AdminPromoTestCase(TestCase):
         self.assertTrue(self.user1.groups.filter(name='admin').exists())
 
         response = self.client.post(reverse('streamwebs:user_promo'), {
-            'users': (self.user1.id),
+            'users_display': self.user1.username,
+            'users': self.user1.id,
             'perms': 'del_admin',
             }
         )
@@ -149,7 +147,8 @@ class AdminPromoTestCase(TestCase):
         self.assertFalse(self.user2.has_perm('streamwebs.can_view_stats'))
 
         response = self.client.post(reverse('streamwebs:user_promo'), {
-            'users': (self.user2.id),
+            'users_display': self.user2.username,
+            'users': self.user2.id,
             'perms': 'add_stats',
             }
         )
@@ -167,34 +166,26 @@ class AdminPromoTestCase(TestCase):
         """Tests that users can have the can_view_stats permission revoked"""
         self.client.login(username='superAdmin', password='superpassword')
 
-        # user1 is an admin; user2 is a regular user but has the stats perm
-        self.user1.groups.add(self.admins)
+        # user2 is a regular user but has the stats perm
         self.user2.user_permissions.add(self.can_stats)
 
-        self.assertTrue(self.user1.groups.filter(name='admin').exists())
         self.assertFalse(self.user2.groups.filter(name='admin').exists())
         self.assertTrue(self.user2.has_perm('streamwebs.can_view_stats'))
 
         response = self.client.post(reverse('streamwebs:user_promo'), {
-            'users': (self.user1.id, self.user2.id),
+            'users_display': self.user2.username,
+            'users': self.user2.id,
             'perms': 'del_stats',
             }
         )
-        # user1 and user2 should both be regular users now w/o the stats perm.
-        # user1 still has the upload perm.
-        self.user1 = User.objects.get(pk=2)     # re-query: perms are cached
-        self.user2 = User.objects.get(pk=7)
+        # user2 should be a regular user now w/o the stats perm.
+        self.user2 = User.objects.get(pk=7)     #re-query: perms are cached
 
-        self.assertFalse(self.user1.groups.filter(name='admin').exists())
         self.assertFalse(self.user2.groups.filter(name='admin').exists())
 
-        self.assertTrue(self.user1.has_perm('streamwebs.can_upload_resources'))
-        self.assertFalse(self.user1.has_perm('streamwebs.can_view_stats'))
         self.assertFalse(self.user2.has_perm('streamwebs.can_view_stats'))
 
         messages = list(response.context['msgs'])
-        self.assertEquals(len(messages), 2)
-        self.assertIn(self.user1.username + self.del_stats_msg, messages)
         self.assertIn(self.user2.username + self.del_stats_msg, messages)
 
     def test_add_upload_perm_for_users(self):
@@ -205,14 +196,14 @@ class AdminPromoTestCase(TestCase):
         self.assertFalse(self.user1.groups.filter(name='admin').exists())
 
         response = self.client.post(reverse('streamwebs:user_promo'), {
-            'users': (self.user1.id),
+            'users_display': self.user1.username,
+            'users': self.user1.id,
             'perms': 'add_upload',
             }
         )
         self.assertTrue(self.user1.has_perm('streamwebs.can_upload_resources'))
 
         messages = list(response.context['msgs'])
-        self.assertEquals(len(messages), 1)
         self.assertEquals(messages[0],
                           self.user1.username + self.add_upload_msg)
 
@@ -220,33 +211,25 @@ class AdminPromoTestCase(TestCase):
         """Tests that users can have the can_upload_stats permission revoked"""
         self.client.login(username='superAdmin', password='superpassword')
 
-        # user1 is an admin; user2 is a regular user but has the upload perm
+        # user1 is an admin
         self.user1.groups.add(self.admins)
-        self.user2.user_permissions.add(self.can_upload)
 
         self.assertTrue(self.user1.groups.filter(name='admin').exists())
-        self.assertFalse(self.user2.groups.filter(name='admin').exists())
-        self.assertTrue(self.user2.has_perm('streamwebs.can_upload_resources'))
 
         response = self.client.post(reverse('streamwebs:user_promo'), {
-            'users': (self.user1.id, self.user2.id),
+            'users_display': self.user1.username,
+            'users': self.user1.id,
             'perms': 'del_upload',
             }
         )
-        # user1 and user2 should both be regular users now w/o the upload perm.
-        # user1 still has the stats perm.
+        # user1 is a regular user now w/o the upload perm. They still have the
+        # stats perm.
         self.user1 = User.objects.get(pk=2)     # re-query: perms are cached
-        self.user2 = User.objects.get(pk=7)
 
         self.assertFalse(self.user1.groups.filter(name='admin').exists())
-        self.assertFalse(self.user2.groups.filter(name='admin').exists())
 
         self.assertFalse(self.user1.has_perm(
             'streamwebs.can_upload_resources'))
-        self.assertFalse(self.user2.has_perm(
-            'streamwebs.can_upload_resources'))
 
         messages = list(response.context['msgs'])
-        self.assertEquals(len(messages), 2)
         self.assertIn(self.user1.username + self.del_upload_msg, messages)
-        self.assertIn(self.user2.username + self.del_upload_msg, messages)

--- a/streamwebs_frontend/streamwebs/urls.py
+++ b/streamwebs_frontend/streamwebs/urls.py
@@ -91,6 +91,8 @@ urlpatterns = [
     url(r'^statistics/$', views.admin_site_statistics, name='stats'),
     url(r'^user-promotion/$', views.admin_user_promotion, name='user_promo'),
 
+    url(r'^users_auto_complete/$', views.users_auto_complete, name='users_auto_complete'),
+
     url(r'^register/$', views.register, name='register'),
     url(r'^login/$', views.user_login, name='login'),
     url(r'^logout/$', views.user_logout, name='logout'),

--- a/streamwebs_frontend/streamwebs/urls.py
+++ b/streamwebs_frontend/streamwebs/urls.py
@@ -91,7 +91,8 @@ urlpatterns = [
     url(r'^statistics/$', views.admin_site_statistics, name='stats'),
     url(r'^user-promotion/$', views.admin_user_promotion, name='user_promo'),
 
-    url(r'^users_auto_complete/$', views.users_auto_complete, name='users_auto_complete'),
+    url(r'^users_auto_complete/$', views.users_auto_complete,
+        name='users_auto_complete'),
 
     url(r'^register/$', views.register, name='register'),
     url(r'^login/$', views.user_login, name='login'),

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -1108,6 +1108,7 @@ def admin_user_promotion(request):
         }
     )
 
+
 def users_auto_complete(request):
     users = User.objects.all()
     users_list = []
@@ -1116,4 +1117,5 @@ def users_auto_complete(request):
         u_dict = {'id': u.id, 'label': u.username, 'value': u.username}
         users_list.append(u_dict)
 
-    return HttpResponse(json.dumps(users_list), content_type='application/json') 
+    return HttpResponse(json.dumps(users_list),
+                        content_type='application/json')

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -854,7 +854,7 @@ def admin_site_statistics(request):
     # A user is defined as "active" if they have logged in w/in the last 3 yrs
     today = datetime.date.today()
     user_start = datetime.date(today.year - 3, today.month, today.day)
-    start = datetime.date(1970, 1, 1)
+    start = datetime.date(2005, 1, 1)
     end = today
 
     if request.method == 'POST':


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Starts issue #266 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [ ] Search functionality for users in user promotion (mostly complete; one last snag to iron out, detailed below)
- [ ] Tests to reflect the changes implemented for the above checkbox ^^^
- [ ] Better user display (print out in a table or something) in user promotion
- [ ] Materialize pagination in user promotion's user display (see #250 for details on how pagination is currently implemented using Django's paginator, as well as how the form works in general)
- [x] Continue prettifying the statistics page; see #266 for a link to work that @athai started

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. run tests: ``docker-compose run web bash`` and ``cd streamwebs_frontend python manage.py test streamwebs/tests/*``
2. Make sure your migrations current and have been applied. I usually nuke 0001 and remake it to do this.
3. Create a superuser: ``python manage.py createsuperuser``
4. Load in test users if not already present: ``cd ../data_scripts`` and ``./get_schools.py`` and ``./get_users.py``
5. ``docker-compose up``; go to http://localhost:8000/user-promotion/ and http://localhost:8000/statistics/ or click the links in the nav bar

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->
- all tests should pass 
- user promotion's search/autocomplete functionality for the users field is somewhat implemented. All usernames show up when you type in the field instead of just the names that match, but you are able to click on a user, have it be selected, and then submit the form (the default permission applied is "promote to admin". However, I'm having an issue where jQuery/jQuery UI and Materialize won't mesh well; there's probably dependency/versioning stuff going on. The permissions dropdown will not render because it depends on ``$('select').material_select();`` (commented out on line 60 of ``templates/streamwebs/admin``); which in turn depends on various outside scripts that, when included, makes the users autocomplete useless. In summary, I can only render either the users field correctly, or the permissions field-- never both at once. I'm assuming it's just a dependency/versioning thing. When you remove the ``{% extends 'streamwebs/base.html' %} at the top, you can see that both fields are present and usable. 

I've been referencing http://guiqinqian.blogspot.com/2012/01/using-jquery-auto-complete-in-django.html  and https://jqueryui.com/autocomplete/ 