### PR TITLE
Remove macro graph time selectors

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/macroinvertebrates.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/macroinvertebrates.html
@@ -21,24 +21,9 @@
   <div class="container">
   <div class="row">
     <form action="">
-      <div id="dates">
-        <div class="col s2 offset-s1">
-          <h5>{% trans "Date range:" %}</h5>
-        </div>
-        <div class="col s4">
-          <label for="date-start">{% trans "After" %}</label>
-          <input type="date" name="date" id="date-start" class="datepicker"
-                 value=""/>
-        </div>
-        <div class="col s4">
-          <label for="date-end">{% trans "Before" %}</label>
-          <input type="date" name="date" id="date-end" class="datepicker"
-                 value=""/>
-        </div>
-      </div>
       <div id="type">
         <div class="col s2 offset-s1">
-          <h5>{% trans "Graph type:" %}</h5>
+          <h7>{% trans "Graph type:" %}</h7>
         </div>
         <div class="col s4">
           <input type="radio" name="type" id="type-bar" value="bar" checked/>


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #306 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Removed time selector
- [X] make graph options fit better

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Look at macro graph.
2. See no time selectors.
3. Example: http://localhost:8000/sites/bear-creek/macros

@osuosl/devs
