### PR TITLE
Search sites now populates map with only relevant markers (to search)

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -1,9 +1,7 @@
 var dropdownShown = 0;
 var markerList = [];
 function search() {
-  console.log('Searched!');
   var search_value = $('#search').val().toLowerCase();
-  console.log(search_value);
   for(var i = 0; i < markerList.length; i++){ //searches marker list for name
     if(!markerList[i].title.toLowerCase().includes(search_value)){
       markerList[i].setVisible(false);

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -1,24 +1,17 @@
 var dropdownShown = 0;
+var markerList = [];
 function search() {
-    console.log('Searched!');
-
-    var search_value = $('#search').val().toLowerCase();
-
-    dropdownShown = 0;
-
-    $('.search-item').each(function () {
-        var name = $(this).text().toLowerCase();
-        var search_point = $('#search').offset().top + parseInt($('#search').css('height'));
-
-        if (search_value && name.includes(search_value)) {
-            $(this).removeClass('hide');
-            $(this).css("top", search_point + (dropdownShown * 40));
-            $(this).css("left", $('#search').offset().left);
-            dropdownShown += 1;
-        } else {
-            $(this).addClass('hide');
-        }
-    });
+  console.log('Searched!');
+  var search_value = $('#search').val().toLowerCase();
+  console.log(search_value);
+  for(var i = 0; i < markerList.length; i++){ //searches marker list for name
+    if(!markerList[i].title.toLowerCase().includes(search_value)){
+      markerList[i].setVisible(false);
+    }
+    else{ //this resets the map if user deletes from search box
+      markerList[i].setVisible(true);
+    }
+  }
 }
 
 var map;
@@ -37,7 +30,6 @@ function initialize() {
 
     var latSum = 0, lngSum = 0;
 
-    var markerList = [];
     var infoWindows = [];
 
     for (var i = 0; i < sites.length; i++) {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -5,6 +5,7 @@
 
 
 {% block scripts %}
+<!-- AIzaSyC2tnAw9ftf57TJ34147kcW69sChT917gs-->
 <script src="https://maps.googleapis.com/maps/api/js?key={{ maps_api }}"></script>
 <script type="text/javascript" src="http://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
 
@@ -39,7 +40,7 @@
             <div class="input-field">
               <input id="search" type="search" autocomplete="off"
                      placeholder="{% trans 'Search sites' %}"
-                     oninput="search()">
+                     onkeydown="search()">
               <label for="search"><i class="material-icons">search</i></label>
               <i class="material-icons">close</i>
 

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -5,7 +5,6 @@
 
 
 {% block scripts %}
-<!-- AIzaSyC2tnAw9ftf57TJ34147kcW69sChT917gs-->
 <script src="https://maps.googleapis.com/maps/api/js?key={{ maps_api }}"></script>
 <script type="text/javascript" src="http://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #314 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Removed Drop down from search
- [X] Markers are hidden from map if they do not match search
- [X] Markers are repopulated when user deletes search query

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Fire up localhost:8000
2. Navigate to maps (you may need to change api key in sites.html to get map to show)
3. Search Sites
4. See that sites are added or removed based on search, regardless of case

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
This map search works
```

@osuosl/devs
