### PR TITLE
Set docs theme to 'default' so that the RTD theme is used

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,7 +109,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   about.rst
    usage.rst
    outline.rst
    dev_docs.rst


### PR DESCRIPTION
Also include the about page as it was missing.

## Changes in this PR.

- [X] Change HTML theme to default
- [X] Add about.rst

## Testing this PR.

1. cd docs
2. make html

### Expected Output.

When you view the docs it should show up using the default theme.

@osuosl/devs
