### PR TITLE
fixes sensitive/intolerant, and site sorting, and field notes view

### DIFF
--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -89,7 +89,7 @@ class MacroinvertebratesForm(forms.ModelForm):
 
     class Meta:
         model = Macroinvertebrates
-        widgets={
+        widgets = {
             'notes': forms.Textarea(
                 attrs={'class': 'materialize-textarea'})
         }

--- a/streamwebs_frontend/streamwebs/forms.py
+++ b/streamwebs_frontend/streamwebs/forms.py
@@ -89,6 +89,10 @@ class MacroinvertebratesForm(forms.ModelForm):
 
     class Meta:
         model = Macroinvertebrates
+        widgets={
+            'notes': forms.Textarea(
+                attrs={'class': 'materialize-textarea'})
+        }
         fields = ('date_time', 'weather', 'time_spent',
                   'num_people', 'water_type', 'caddisfly', 'mayfly',
                   'riffle_beetle', 'stonefly', 'water_penny', 'dobsonfly',

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -55,7 +55,7 @@
         <div class="row">
           <h5 align=center>{% trans "Sensitivity to pollution" %}</h5>
           <div class="col s4">
-            <h6 align=center>{% trans "Sensitive/intolerant" %}</h6>
+            <h6 align=center>{% trans "Sensitive" %}</h6>
             <table>
               {% for bug in intolerant %}
                 <tr>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
@@ -51,7 +51,7 @@
     <div class="row">
       <h5 align="center">{% trans "Sensitivity to pollution" %}</h5>
       <div class="col s3">
-        <h6 align=center>{% trans "Sensitive/Intolerant" %}</h6>
+        <h6 align=center>{% trans "Sensitive"%}</h6>
         <table class="bordered">
           <thead>
             <tr>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
@@ -6,6 +6,14 @@
 
 
 {% block content %}
+
+<style>
+.notes{
+  overflow-wrap: break-word;
+}
+</style>
+
+}
   <div class="container">
     {% if messages %}
       {% for message in messages %}
@@ -42,7 +50,7 @@
       <div class="col s6">
           <p>{% trans "Weather" %}: {{ data.weather }}</p>
       </div>
-      <div class="col s12">
+      <div class="notes col s12">
           {% if data.notes %}
           <p>{% trans "Field notes" %}: {{ data.notes }}</p>
           {% endif %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -58,7 +58,7 @@
         <a href="#!" class="dropdown-button btn select-button teal darken-4" data-activates='dropdown'>{% trans "Select Site" %}<i class="material-icons right">arrow_drop_down</i></a>
         <ul id="dropdown" class="dropdown-content">
         {% for site in sites %}
-            <li><a href="{{site.site_slug}}" class="teal-text text-darken-4">{{site.site_name}}</a></li>
+            <li><a href="{{site.site_slug}}" class="teal-text text-darken-4">{{ site.site_name }}</a></li>
         {% endfor %}
         </ul>
     </div>

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -79,7 +79,7 @@ def create_site(request):
 
 def sites(request):
     """ View for streamwebs/sites """
-    site_list = Site.objects.filter(active=True)
+    site_list = Site.objects.filter(active=True).order_by('site_name')
     return render(request, 'streamwebs/sites.html', {
         'sites': site_list,
         'maps_api': settings.GOOGLE_MAPS_API,

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -538,7 +538,6 @@ def macroinvertebrate_edit(request, site_slug):
 
     # the following are the form's fields broken up into chunks to
     # facilitate CSS manipulation in the template
-    print(list(macro_form))
     intolerant = list(macro_form)[5:11]
     somewhat = list(macro_form)[11:20]
     tolerant = list(macro_form)[20:26]

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -179,6 +179,7 @@ def site(request, site_slug):
 
     data.sort(cmp=sort_date, key=lambda x: x['date'])
     data.sort(key=lambda x: -x['school_id'])
+    pages = len(data)/10 + 1
     data_len_range = range(2, len(data)/10 + 2)
     data = add_school_name(data)
 
@@ -188,6 +189,7 @@ def site(request, site_slug):
         'map_type': settings.GOOGLE_MAPS_TYPE,
         'data': json.dumps(data, cls=DjangoJSONEncoder),
         'data_len_range': data_len_range,
+        'pages': pages,
         'has_wq': len(wq_sheets) > 0,
         'has_macros': len(macro_sheets) > 0,
         'has_transect': len(transect_sheets) > 0,
@@ -536,9 +538,10 @@ def macroinvertebrate_edit(request, site_slug):
 
     # the following are the form's fields broken up into chunks to
     # facilitate CSS manipulation in the template
+    print(list(macro_form))
     intolerant = list(macro_form)[5:11]
     somewhat = list(macro_form)[11:20]
-    tolerant = list(macro_form)[20:28]
+    tolerant = list(macro_form)[20:26]
 
     if request.method == 'POST':
         macro_form = MacroinvertebratesForm(data=request.POST)


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #350 #368 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Changed "Sensitive/Intolerant" to "sensitive"
- [X] Added to general.py to sort site list, so that when sites are added and edited, they go to their respective spots     on the site select drop down
- [X] Fixed field notes in macro_edit to be materialized and in the right spot (works)
- [X] changed the field notes in macro_view to wrap within the container instead of over flowing

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Navigate to shafer creek or any site
2. Add a macro invertebrate datasheet 
3. See that 'Sensitive/Intolerant' is now 'Sensitive' (first col)
4. Add some field notes
5. After adding, see that number 4 is present in viewing
6. See that field notes behave more normally now.

1. Add or edit a site -- change site name
2. Check site dropdown to see that the name of the edited site is in it's respective place in the list.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
All these things above work!
```

@osuosl/devs
