### PR TITLE
Added fix to site_detail pagination

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_view.html
@@ -38,6 +38,9 @@
       </div>
       <div class="col s6">
           <p>{% trans "Percent EPT" %}: {{ EPT|floatformat:2 }}%</p>
+          <p><b>Note: </b>
+            EPT is the total number of caddisflies, mayflies, and stoneflies found divided by number of all bugs
+          </p>
       </div>
       <div class="col s6">
           <p>{% trans "Weather" %}: {{ data.weather }}</p>

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -179,7 +179,16 @@ def site(request, site_slug):
 
     data.sort(cmp=sort_date, key=lambda x: x['date'])
     data.sort(key=lambda x: -x['school_id'])
-    data_len_range = range(2, len(data)/10 + 2)
+
+    num_schools = count_schools(data)
+    number_item = len(data) + num_schools
+    
+    pages = (number_item)/10;
+    if number_item % 10 != 0:
+        pages += 1
+
+    data_len_range = range(2, pages + 1)
+
     data = add_school_name(data)
 
     return render(request, 'streamwebs/site_detail.html', {
@@ -188,6 +197,7 @@ def site(request, site_slug):
         'map_type': settings.GOOGLE_MAPS_TYPE,
         'data': json.dumps(data, cls=DjangoJSONEncoder),
         'data_len_range': data_len_range,
+        'pages': pages,
         'has_wq': len(wq_sheets) > 0,
         'has_macros': len(macro_sheets) > 0,
         'has_transect': len(transect_sheets) > 0,
@@ -195,6 +205,15 @@ def site(request, site_slug):
         'has_soil': len(soil_sheets) > 0
     })
 
+def count_schools(data):
+    schools = []
+    num_schools = 0
+    for i in data:
+        if i['school_id'] not in schools:
+            schools.append(i['school_id'])
+            num_schools += 1
+    print(schools)
+    return num_schools
 
 def add_school_name(data):
     if len(data) == 0:

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -213,7 +213,6 @@ def count_schools(data):
         if i['school_id'] not in schools:
             schools.append(i['school_id'])
             num_schools += 1
-    print(schools)
     return num_schools
 
 

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -182,8 +182,8 @@ def site(request, site_slug):
 
     num_schools = count_schools(data)
     number_item = len(data) + num_schools
-    
-    pages = (number_item)/10;
+
+    pages = (number_item)/10
     if number_item % 10 != 0:
         pages += 1
 
@@ -205,6 +205,7 @@ def site(request, site_slug):
         'has_soil': len(soil_sheets) > 0
     })
 
+
 def count_schools(data):
     schools = []
     num_schools = 0
@@ -214,6 +215,7 @@ def count_schools(data):
             num_schools += 1
     print(schools)
     return num_schools
+
 
 def add_school_name(data):
     if len(data) == 0:


### PR DESCRIPTION
fixes issue #348
fixes partial issue #350 (Since i had 10 minutes might as well)(The other issue fixed by Bailey)

## Changes in this PR.

- [X] Added the number of schools when counting number of pages for site_detail pagination
- [X] In macro_view, added a note below EPT to explain what EPT is

## Testing this PR.

1. Find site with data that has a good number of data, that has number of data almost divisible by ten, but adding the number of schools, will add up to that. For example, 29 data sheets, with 3 schools. if number of schools added to data sheet, then it would be 32, just over 30.
Note: if data cannot be found, create your own data. Good place to start: SE belmont 27 data, 2 schools.
2. Go to a macro_view, see if the note is present

### Expected Output.

1. After adding data, the data is present in the pagination.
2. The macro_view is present.

```
$ make test
[... test output ...]
```

@osuosl/devs
