### PR TITLE
Fixed riparian export button

### DIFF
--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -199,7 +199,7 @@ def site(request, site_slug):
         'pages': pages,
         'has_wq': len(wq_sheets) > 0,
         'has_macros': len(macro_sheets) > 0,
-        'has_transect': len(transect_sheets) > 0,
+        'has_transects': len(transect_sheets) > 0,
         'has_cc': len(canopy_sheets) > 0,
         'has_soil': len(soil_sheets) > 0
     })


### PR DESCRIPTION
fixes issue #xx

## Changes in this PR.

- [X] Fixed a typo in general.py, now the site_detail can export riparian graph

## Testing this PR.

1. Go to a site that has rip datasheets, or add a rip datasheets, see if the export dropdown has rip

### Expected Output.
1. It has

```
$ make test
[... test output ...]
```

@osuosl/devs
