### PR TITLE
Jerryp/add static serve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ flake8==3.3.0
 django-recaptcha==1.3.0
 django-queryset-csv==1.0.0
 requests==2.13.0
+dj-static==0.0.6

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -20,11 +20,11 @@ import sys
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT_ROOT = os.path.join(BASE_DIR, 'streamwebs')
-STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
+STATIC_ROOT = 'staticfiles'
 LOCALE_PATHS = [
     '../locale/',
 ]
-MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'media')
+MEDIA_ROOT = 'media'
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 

--- a/streamwebs_frontend/streamwebs_frontend/wsgi.py
+++ b/streamwebs_frontend/streamwebs_frontend/wsgi.py
@@ -10,7 +10,8 @@ https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from dj_static import Cling
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "streamwebs_frontend.settings")
 
-application = get_wsgi_application()
+application = Cling(get_wsgi_application())


### PR DESCRIPTION
fixes issue #379 

## Changes in this PR.

- [X] Added dj-static middleware for production server static file serving.

## Testing this PR.

1. Re-deploy the application on to the server, see if all static files load (css, js, .jpg, .png)

### Expected Output.

1. All the static files load.

```
$ make test
[... test output ...]
```

@osuosl/devs
