### PR TITLE
Added date range for macro graph, added date-range selection, as well…

### DIFF
--- a/streamwebs_frontend/streamwebs/models.py
+++ b/streamwebs_frontend/streamwebs/models.py
@@ -835,9 +835,6 @@ class Macroinvertebrates(models.Model):
         # the water quality rating is just the sum of the three scores
         self.wq_rating = (self.sensitive_total +
                           self.somewhat_sensitive_total + self.tolerant_total)
-        self.sensitive_total = sum(sensitive)
-        self.somewhat_sensitive_total = sum(somewhat)
-        self.tolerant_total = sum(tolerant)
 
         super(Macroinvertebrates, self).save()
 

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/macros.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/graphs/macros.js
@@ -364,17 +364,6 @@ var useLineGraph = function useLineGraph() {
             .text(function (d) {
                 return d.name;
             });
-
-        var dateRange = 'Date Range: ' + formatted[0].date + ' ~ ' +
-            formatted[formatted.length - 1].date;
-
-        g.append('text')
-            .attr('x', 260)
-            .attr('y', height + margin.bottom+ 40)
-            .attr('dy', '.35em')
-            .style('font-size', '14px')
-            .text(dateRange);
-
     }
 };
 
@@ -698,11 +687,44 @@ $(window).resize(function () {
     }
 });
 
+var addDateRange = function addDateRange() {
+    console.log(window.data_time);
+    var count = 0;
+    for (key in window.data_time) {
+        count++;
+    }
+    if (count > 0) {
+        var first = 1;
+        var min, max;
+        for (key in window.data_time) {
+            if (first == 1) {
+                var min = key;
+                var max = key;
+                first--;
+            }
+            else {
+                if (key < min) min = key;
+                if (key > max) max = key;
+            }
+        }
+        var min_date = new Date(0);
+        var max_date = new Date(0);
+        min_date.setUTCSeconds(min);
+        max_date.setUTCSeconds(max);
+        var date_range = "";
+        var date_range = date_range + min_date.getFullYear().toString()
+            + "-" + min_date.getDate().toString() + "-" + (min_date.getMonth() + 1).toString()
+            + " ~ " + max_date.getFullYear().toString()
+            + "-" + max_date.getDate().toString() + "-" + (max_date.getMonth() + 1).toString()
+        $('p.date-range').text('Date range of data: ' + date_range);
+    }
+}
+
 $(function () {
     $('input[type=date]').val('');
     $('#date-start').change(changeRangeStart);
     $('#date-end').change(changeRangeEnd);
-
+    addDateRange();
     $('input[type=radio]').fix_radios();
     $('input[name=type]').change(function () {
         if ($('input[name=type]:checked').val() === 'line') {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/macroinvertebrates.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/macroinvertebrates.html
@@ -16,6 +16,26 @@
     <h3 align="center" class="teal-text">
       {{ site.site_name }} {% trans "Macroinvertebrates" %}
     </h3>
+    <br/>
+    <p class="date-range"></p>
+    <br/>
+    <form action="">
+      <div id="dates">
+        <p>{% trans "Set Date Range:" %}</p>
+
+        <div class="row">
+          <div class="col s6">
+            <label for="date-start">{% trans "Begin" %}</label>
+            <input type="date" name="date" class="datepicker" id="date-start"
+                   value=""/>
+          </div>
+          <div class="col s6">
+            <label for="date-end">{% trans "End" %}</label>
+            <input type="date" name="date" class="datepicker" id="date-end" value=""/>
+          </div>
+        </div>
+      </div>
+    </form>
     <div class="row">
       <form action="">
         <div id="type">
@@ -69,21 +89,15 @@
 {% endblock %}
 
 {% block scripts %}
-  <script>
-    $('select').material_select();
-    /*$('.datepicker').pickadate({
-      today: '',
-      selectMonths: true, // Creates a dropdown to control month
-      selectYears: 100, // Creates a dropdown of 15 years to control year
-      max: true, // set max to today
-      format: 'yyyy-mm-dd',
-    });*/
-  </script>
-
   <script type="application/javascript">
     window.data_time = {{data.time|safe}};
     window.data_summ = {{data.summary|safe}};
     var siteId = '{{site.site_slug}}';
+
+    $('.datepicker').pickadate({
+      selectMonths: true,
+      selectYears: 20,
+    });
   </script>
 
   <script type="application/javascript"

--- a/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
@@ -145,7 +145,7 @@ class MacroTestCase(TestCase):
         self.assertEqual(macros.stonefly, 1)
         self.assertEqual(macros.water_penny, 3)
         self.assertEqual(macros.dobsonfly, 0)
-        self.assertEqual(macros.sensitive_total, 7)
+        self.assertEqual(macros.sensitive_total, 12)
 
         # Somewhat tolerant
         self.assertEqual(macros.clam_or_mussel, 4)
@@ -157,7 +157,7 @@ class MacroTestCase(TestCase):
         self.assertEqual(macros.fishfly, 7)
         self.assertEqual(macros.alderfly, 8)
         self.assertEqual(macros.mite, 8)
-        self.assertEqual(macros.somewhat_sensitive_total, 49)
+        self.assertEqual(macros.somewhat_sensitive_total, 18)
 
         # Tolerant
         self.assertEqual(macros.aquatic_worm, 12)
@@ -169,6 +169,6 @@ class MacroTestCase(TestCase):
         self.assertEqual(macros.tolerant_total, 52)
 
         # Overall water quality rating
-        self.assertEqual(macros.wq_rating, 36)
+        self.assertEqual(macros.wq_rating, 7)
 
         self.assertEqual(macros.notes, '')

--- a/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
+++ b/streamwebs_frontend/streamwebs/tests/models/test_macroinvert.py
@@ -166,9 +166,9 @@ class MacroTestCase(TestCase):
         self.assertEqual(macros.midge, 7)
         self.assertEqual(macros.snail, 5)
         self.assertEqual(macros.mosquito_larva, 11)
-        self.assertEqual(macros.tolerant_total, 52)
+        self.assertEqual(macros.tolerant_total, 6)
 
         # Overall water quality rating
-        self.assertEqual(macros.wq_rating, 7)
+        self.assertEqual(macros.wq_rating, 36)
 
         self.assertEqual(macros.notes, '')


### PR DESCRIPTION
fixes issue #440 #462

## Changes in this PR.

- [X] Reverted changes to macro total count in datasheets
- [X] Added time selection function in macro graph
- [X] Added date range for macro graph

## Testing this PR.

1. create a macro datasheet, and check if the count scheme is the same as the paper version in "resources"
2. add some random macro datasheets, make sure dates are far apart
3. Go to macro graph, see if date selection works fine for filtering data
4. Check if date range displayed is correct

### Expected Output.
1. macro data total count scheme the same
2. macro graph date-selection works, date-range displayed correctly.

```
$ make test
[... test output ...]
```

@osuosl/devs
