### PR TITLE
Add script to automate updating the CSV data from the Drupal site

### DIFF
--- a/data_scripts/get_additional_wq.py
+++ b/data_scripts/get_additional_wq.py
@@ -14,7 +14,7 @@ application = get_wsgi_application()
 from streamwebs.models import WQ_Sample  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datapath = '../sw_data/wq_csvs/'
 else:
     datapath = '../csvs/wq_csvs/'

--- a/data_scripts/get_all.sh
+++ b/data_scripts/get_all.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 # Run all migration scripts in appropriate order
 ./get_sites.py
 ./get_schools.py

--- a/data_scripts/get_cc.py
+++ b/data_scripts/get_cc.py
@@ -61,7 +61,7 @@ CCs = {}
 directions = ['north', 'east', 'south', 'west']
 
 for dir in directions:
-    if os.path.isdir("../streamwebs_frontend/sw_data/"):
+    if os.path.isdir("../sw_data/"):
         datafile = '../sw_data/cc_' + dir + '.csv'
     else:
         datafile = '../csvs/cc_' + dir + '.csv'

--- a/data_scripts/get_macros.py
+++ b/data_scripts/get_macros.py
@@ -15,7 +15,7 @@ from streamwebs.models import Site  # NOQA
 from streamwebs.models import Macroinvertebrates  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/macros.csv'
 else:
     datafile = '../csvs/macros.csv'

--- a/data_scripts/get_required_fields.py
+++ b/data_scripts/get_required_fields.py
@@ -15,7 +15,7 @@ from streamwebs.models import Water_Quality  # NOQA
 from streamwebs.models import WQ_Sample  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datapath = '../sw_data/wq_csvs/'
 else:
     datapath = '../csvs/wq_csvs/'

--- a/data_scripts/get_schools.py
+++ b/data_scripts/get_schools.py
@@ -13,7 +13,7 @@ application = get_wsgi_application()
 
 from streamwebs.models import School  # NOQA
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/schools_info.csv'
 else:
     datafile = '../csvs/schools_info.csv'

--- a/data_scripts/get_sites.py
+++ b/data_scripts/get_sites.py
@@ -26,7 +26,7 @@ def num(x):
         return x
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/sites.csv'
 else:
     datafile = '../csvs/sites.csv'

--- a/data_scripts/get_soil.py
+++ b/data_scripts/get_soil.py
@@ -15,7 +15,7 @@ from streamwebs.models import Soil_Survey, Site  # NOQA
 from streamwebs.util.ft_to_m import feet_to_meters  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data"):
+if os.path.isdir("../sw_data"):
     datafile = '../sw_data/soil_survey.csv'
 else:
     datafile = '../csvs/soil_survey.csv'

--- a/data_scripts/get_transects.py
+++ b/data_scripts/get_transects.py
@@ -16,7 +16,7 @@ from streamwebs.models import RiparianTransect  # NOQA
 from streamwebs.models import TransectZone  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datapath = '../sw_data/'
 else:
     datapath = '../csvs/'

--- a/data_scripts/get_users.py
+++ b/data_scripts/get_users.py
@@ -21,7 +21,7 @@ from streamwebs.models import UserProfile, School  # NOQA
 # "Uid","Name","E-mail","Active","Created date","Last login","Last access",
 # "Roles","# of Submissions","School","First name","Last name","Date of birth"
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     users_list = '../sw_data/users.csv'
 else:
     users_list = '../csvs/users.csv'

--- a/data_scripts/get_wq_basic.py
+++ b/data_scripts/get_wq_basic.py
@@ -16,7 +16,7 @@ from streamwebs.models import Site  # NOQA
 from streamwebs.models import Water_Quality  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/wq_csvs/water_quality.csv'
 else:
     datafile = '../csvs/wq_csvs/water_quality.csv'

--- a/data_scripts/rename_schools.py
+++ b/data_scripts/rename_schools.py
@@ -13,7 +13,7 @@ application = get_wsgi_application()
 
 from streamwebs.models import School, SchoolRelations # NOQA
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/active_schools.csv'
 else:
     datafile = '../csvs/active_schools.csv'

--- a/data_scripts/set_schools.py
+++ b/data_scripts/set_schools.py
@@ -17,7 +17,7 @@ from streamwebs.models import (  # NOQA
     SchoolRelations, Macroinvertebrates, Soil_Survey, RiparianTransect,
     Water_Quality, Canopy_Cover)
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/active_schools.csv'
 else:
     datafile = '../csvs/active_schools.csv'

--- a/data_scripts/set_tools.py
+++ b/data_scripts/set_tools.py
@@ -15,7 +15,7 @@ from streamwebs.models import Site  # NOQA
 from streamwebs.models import WQ_Sample  # NOQA
 
 
-if os.path.isdir("../streamwebs_frontend/sw_data/"):
+if os.path.isdir("../sw_data/"):
     datafile = '../sw_data/wq_csvs/WQ_sample_tools'
 else:
     datafile = '../csvs/wq_csvs/WQ_sample_tools'

--- a/data_scripts/update-csvs.sh
+++ b/data_scripts/update-csvs.sh
@@ -1,0 +1,32 @@
+set -x
+curl http://streamwebs.org/site_lat_long/csv > sites.csv
+curl http://streamwebs.org/schools/csv > schools_info.csv
+# This requires being logged into the site to pull down all of the data
+# curl http://streamwebs.org/active_users/csv > users.csv
+curl http://streamwebs.org/macro_ds/csv > macros.csv
+curl http://streamwebs.org/water_quality/csv > wq_csvs/water_quality.csv
+curl http://streamwebs.org/wq_water_temp/csv > wq_csvs/WQ_water_temp.csv
+curl http://streamwebs.org/wq_air_temp/csv > wq_csvs/WQ_air_temp.csv
+curl http://streamwebs.org/wq_oxygen/csv > wq_csvs/WQ_oxygen.csv
+curl http://streamwebs.org/wq_pH/csv > wq_csvs/WQ_pH.csv
+curl http://streamwebs.org/wq_turvbidity/csv > wq_csvs/WQ_turbidity.csv
+curl http://streamwebs.org/wq_salt/csv > wq_csvs/WQ_salinity.csv
+curl http://streamwebs.org/wq_conductivity/csv > wq_csvs/WQ_conductivity.csv
+curl http://streamwebs.org/wq_total_solids/csv > wq_csvs/WQ_total_solids.csv
+curl http://streamwebs.org/wq_bod/csv > wq_csvs/WQ_bod.csv
+curl http://streamwebs.org/wq_ammonia/csv > wq_csvs/WQ_ammonia.csv
+curl http://streamwebs.org/wq_nitrite/csv > wq_csvs/WQ_nitrite.csv
+curl http://streamwebs.org/wq_nitrate/csv > wq_csvs/WQ_nitrate.csv
+curl http://streamwebs.org/wq_phosphates/csv > wq_csvs/WQ_phosphates.csv
+curl http://streamwebs.org/wq_fecal_col/csv > wq_csvs/WQ_fecal_col.csv
+curl http://streamwebs.org/wq_sample_tools/csv > wq_csvs/WQ_sample_tools.csv
+curl http://streamwebs.org/transect/csv > rip_transect.csv
+curl http://streamwebs.org/zones/csv > transect_zones.csv
+curl http://streamwebs.org/cc_north/csv > cc_north.csv
+curl http://streamwebs.org/cc_east/csv > cc_east.csv
+curl http://streamwebs.org/cc_south/csv > cc_south.csv
+curl http://streamwebs.org/cc_west/csv > cc_west.csv
+curl http://streamwebs.org/soil_survey/csv > soil_survey.csv
+curl http://streamwebs.org/active_schools_new/csv > active_schools.csv
+
+sed -i '2s;^;"0","Unknown School","Elementary","2009-02-03 14:16","2009-02-03 14:16","1234 Unknown Street","Corvallis","Oregon","97330","United States"\n;' schools_info.csv

--- a/data_scripts/update-csvs.sh
+++ b/data_scripts/update-csvs.sh
@@ -4,6 +4,7 @@ curl http://streamwebs.org/schools/csv > schools_info.csv
 # This requires being logged into the site to pull down all of the data
 # curl http://streamwebs.org/active_users/csv > users.csv
 curl http://streamwebs.org/macro_ds/csv > macros.csv
+mkdir -p wq_csvs
 curl http://streamwebs.org/water_quality/csv > wq_csvs/water_quality.csv
 curl http://streamwebs.org/wq_water_temp/csv > wq_csvs/WQ_water_temp.csv
 curl http://streamwebs.org/wq_air_temp/csv > wq_csvs/WQ_air_temp.csv


### PR DESCRIPTION
Partially fixes issue #461 

This required updating data directly on the current Drupal website to fix some importing issues that were manually fixed with the csv data before. Once this is merged then we can update the data in the ansible side.

## Changes in this PR.

- [X] Add script to automate updating the CSV data from the Drupal site
- [X] Sets the ``get_all.sh`` script to exit on any errors
- [x] Fix path to where ansible puts the csv files
- [x] Automatically create wq_csvs dir

## Testing this PR.

1. ``cd csvs``
2. ``../data_scripts/update-csvs.sh``
3. ``cd ..``
4. ``docker-compose kill && docker-compose rm --all -f``
5. ``docker-compose up -d postgres_host``
6. ``docker-compose up`` After migrations have run, exit
7. ``docker-compose run web bash``
8. ``cd data_scripts``
9. ``./get_all.sh``
10. Exit out of container and run ``docker-compose up``

### Expected Output.

You should see newly added sites, and other data.
