### PR TITLE
Enhance datepicker across all html templates

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
@@ -187,7 +187,6 @@
       // pass event to function
       map.addListener('click', function(e) {
         placeMarker(e.latLng, map);
-        console.log(e.latLng.lat());
         var lat = e.latLng.lat();
         var lng = e.latLng.lng();
         $('span#lat').text(lat);
@@ -234,5 +233,42 @@
         format: 'yyyy-mm-dd',
       });
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -349,9 +349,46 @@
       $("form").bind("keypress", function(e) {
         if (e.keyCode == 13){
           return false;
-          }
-        });
+        }
       });
+    });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
   <script type="application/javascript"
           src="{% static 'streamwebs/js/data.js' %}"></script>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -166,9 +166,46 @@
       $("form").bind("keypress", function(e) {
         if (e.keyCode == 13){
           return false;
-          }
-        });
+        }
       });
+    });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
   <script type="application/javascript"
           src="{% static 'streamwebs/js/data.js' %}"></script>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_add.html
@@ -86,5 +86,42 @@
         format: 'yyyy-mm-dd',
       });
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/photo_point_view.html
@@ -147,5 +147,42 @@
         format: 'yyyy-mm-dd',
       });
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/rip_aqua_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/rip_aqua_edit.html
@@ -319,5 +319,42 @@
         {% endfor %}
       {% endif %}
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -153,6 +153,43 @@
         }
       });
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
   <script type="application/javascript"
           src="{% static 'streamwebs/js/data.js' %}"></script>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
@@ -179,5 +179,42 @@
         }
       }
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality_edit.html
@@ -538,5 +538,42 @@ $(function() {
   toggleSampleFields();
   submitRadioCheck();
 });
+window.onload = function() {
+  $('input.datepicker').on('change', function() {
+    $(this).removeClass('picker__input--active');
+    $(this).attr('aria-expanded', false);
+    var picker = $(this).parent().find('div.picker');
+    picker.removeClass('picker--focused');
+    picker.removeClass('picker--opened');
+    picker.attr('aria-hidden', true);
+    var dateDiv = $(this).find('div.pidkcer__day');
+    $(document.documentElement).css( 'overflow', '' ).
+        css( 'padding-right', '-=' + getScrollbarWidth());
+  });
+
+  $('input.datepicker').on('click', function() {
+    var picker = $(this).parent().find('div.picker');
+    picker.addClass('picker--opened');
+  });
+}
+// From the Materialize source code
+function getScrollbarWidth() {
+  if ( $(document.documentElement).height() <= $(window).height() ) {
+      return 0;
+  }
+  var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+      appendTo( 'body' );
+  var widthWithoutScroll = $outer[0].offsetWidth;
+  // Force adding scrollbars.
+  $outer.css( 'overflow', 'scroll' );
+  // Add the inner div.
+  var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+  // Get the width with scrollbars.
+  var widthWithScroll = $inner[0].offsetWidth;
+  // Remove the divs.
+  $outer.remove();
+  // Return the difference between the widths.
+  return widthWithoutScroll - widthWithScroll;
+}
 </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/macroinvertebrates.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/macroinvertebrates.html
@@ -98,6 +98,43 @@
       selectMonths: true,
       selectYears: 20,
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 
   <script type="application/javascript"

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/water_quality.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/graphs/water_quality.html
@@ -388,6 +388,43 @@
       selectMonths: true,
       selectYears: 20,
     });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
+
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
+      }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 
   <script type="application/javascript"

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/register.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/register.html
@@ -118,36 +118,57 @@
   <script
       src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
   <script>
-      $(document).ready(function () {
-        {% if messages %}
-          {% for message in messages %}
-            Materialize.toast('{{ message }}', 4000, 'green');
-          {% endfor %}
-        {% endif %}
-        $('select').material_select();
-        $('.datepicker').pickadate({
-            today: '',
-            selectMonths: true, // Creates a dropdown to control month
-            selectYears: 100, // Creates a dropdown of 15 years to control year
-            max: true, // set max to today
-            format: 'yyyy-mm-dd',
-        });
+    $(document).ready(function () {
+      {% if messages %}
+        {% for message in messages %}
+          Materialize.toast('{{ message }}', 4000, 'green');
+        {% endfor %}
+      {% endif %}
+      $('select').material_select();
+      $('.datepicker').pickadate({
+          today: '',
+          selectMonths: true, // Creates a dropdown to control month
+          selectYears: 100, // Creates a dropdown of 15 years to control year
+          max: true, // set max to today
+          format: 'yyyy-mm-dd',
       });
-      window.onload = function() {
-          $('input.datepicker').on('change', function() {
-              console.log("HERRO");
-              $(this).removeClass('picker__input--active');
-              $(this).attr('aria-expanded', false);
-              var picker = $('input.datepicker + div.picker');
-              console.log(picker);
-              picker.removeClass('picker--focused');
-              picker.removeClass('picker--opened');
-              picker.attr('aria-hidden', true);
-          });
+    });
+    window.onload = function() {
+      $('input.datepicker').on('change', function() {
+        $(this).removeClass('picker__input--active');
+        $(this).attr('aria-expanded', false);
+        var picker = $(this).parent().find('div.picker');
+        picker.removeClass('picker--focused');
+        picker.removeClass('picker--opened');
+        picker.attr('aria-hidden', true);
+        var dateDiv = $(this).find('div.pidkcer__day');
+        $(document.documentElement).css( 'overflow', '' ).
+            css( 'padding-right', '-=' + getScrollbarWidth());
+      });
 
-          $('input.datepicker').on('click', function() {
-              $('input.datepicker + div.picker').addClass('picker--opened');
-          });
+      $('input.datepicker').on('click', function() {
+        var picker = $(this).parent().find('div.picker');
+        picker.addClass('picker--opened');
+      });
+    }
+    // From the Materialize source code
+    function getScrollbarWidth() {
+      if ( $(document.documentElement).height() <= $(window).height() ) {
+          return 0;
       }
+      var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
+          appendTo( 'body' );
+      var widthWithoutScroll = $outer[0].offsetWidth;
+      // Force adding scrollbars.
+      $outer.css( 'overflow', 'scroll' );
+      // Add the inner div.
+      var $inner = $( '<div style="width:100%" />' ).appendTo( $outer );
+      // Get the width with scrollbars.
+      var widthWithScroll = $inner[0].offsetWidth;
+      // Remove the divs.
+      $outer.remove();
+      // Return the difference between the widths.
+      return widthWithoutScroll - widthWithScroll;
+    }
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
@@ -22,7 +22,6 @@ $(document).ready(function() {
   google.maps.event.addListener(map, 'click', function(e){
     placeMarker(e.latLng, map);
   });
-  console.log({{latitude}});
   var original_marker= new google.maps.LatLng({{ latitude }}, {{ longitude }});
   placeMarker(original_marker,map);
 });


### PR DESCRIPTION
fixes issue #490
IMPORTANT: Issue not fixed unless Renee approves

## Changes in this PR.

- [X] Enhance the datepicker so that it closes on date selection ('click' event)

## Testing this PR.
In datasheets folder:
Camera_point_add, canopy_cover_edit, macroinvertebrate_edit, photo_point_add, photo_point_view, riparian_transect_edit, soil_edit, water_quality_edit, 

In graphs folder:
macroinvertebratese, water_quality

register page as well.

1. Go to the pages above and test the datepicker, make sure clicking on valid dates will close the datepicker, and going back to the datepicker, the selected date is highlighted

### Expected Output.
1. All datepicker works as expected, even if site has multiple datepickers: (camera_point_add, graphs/water_quality, graphs/macro)

```
$ make test
[... test output ...]
```

@osuosl/devs
