### PR TITLE
Media path fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,20 +3,20 @@
 db.sqlite3
 __pycache__/
 venv/
-
+bower_components
+node_modules/
 # Django stuff
 *.log
-
+# Media folders
+data_scripts/media/
+media/
+streamwebs_frontend/media/
+streamwebs_frontend/staticfiles/
 # NFS write temps
 .nfs*
-
 Dockerfile.env
-
 docs/build
-
 *.swp
-
-bower_components
 csvs/test_users.csv
-
+sw_data/
 streamwebs_frontend/streamwebs_frontend/settings.py

--- a/data_scripts/pull-files.sh
+++ b/data_scripts/pull-files.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 DIR=$PWD
-mkdir -p ../media/pp_photos
+mkdir -p ../media/pp_photos ../streamwebs_frontend/media/
 cd ../media/pp_photos
 wget -q -O- http://drupal.streamwebs.org/photo_point_image_files/csv | wget -nc -q -i-
+cd ${DIR}
+cd ../streamwebs_frontend/media/
+ln -sf ../../media/pp_photos/ .
 echo "Photo Point Images pulled from drupal site."
 cd $DIR
 mkdir -p ../media/site_photos
 cd ../media/site_photos
 wget -q -O- http://drupal.streamwebs.org/site_images | wget -nc -q -i-
+cd ${DIR}
+cd ../streamwebs_frontend/media/
+ln -sf ../../media/site_photos/ .
 echo "Site Images pulled from drupal site."


### PR DESCRIPTION
## Changes in this PR.

- [X] Adds symlinks to media folders so they show up in staging/production properly
- [X] Update ``.gitignore`` to ignore files seen in staging/production

## Testing this PR.

1. ``cd data_scripts``
1. ``./pull-files.sh``

### Expected Output.
Should run without any errors and you should also see symlinks like this:

``` console
$ pwd
/home/centos/streamwebs
$ ls -l streamwebs_frontend/media/
total 0
lrwxrwxrwx 1 root root 22 Oct 24 16:18 pp_photos -> ../../media/pp_photos/
lrwxrwxrwx 1 root root 24 Oct 24 16:18 site_photos -> ../../media/site_photos/
```