### PR TITLE
Escape the site.description for javascript and truncate

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -49,7 +49,7 @@ function initialize() {
         markerList[i].index = i;
 
         infoWindows[i] = new google.maps.InfoWindow({
-            content: '<p><a href="' + site.slug + '">' + site.name + '</a></p>',
+            content: '<p><a href="' + site.slug + '">' + site.name + '</a></p><img src="' + site.image + '" width="55" height="55">',
         });
 
         markerList[i].addListener('click', function () {

--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/sites.js
@@ -49,7 +49,7 @@ function initialize() {
         markerList[i].index = i;
 
         infoWindows[i] = new google.maps.InfoWindow({
-            content: '<p><a href="' + site.slug + '">' + site.name + '</a></><p>' + site.description + '</p>',
+            content: '<p><a href="' + site.slug + '">' + site.name + '</a></p>',
         });
 
         markerList[i].addListener('click', function () {

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -80,7 +80,7 @@ sites.push({
   id: "{{site.id}}",
   slug: "{{site.site_slug}}",
   name: "{{site.site_name}}",
-  description: "{{site.description|escapejs}}",
+  description: "{{site.description|escapejs|truncatewords:50}}",
 
   {% language "en-us" %}
   lat: {{site.location.y}},

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -80,6 +80,11 @@ sites.push({
   id: "{{site.id}}",
   slug: "{{site.site_slug}}",
   name: "{{site.site_name}}",
+  {% if site.image %}
+  image: "/media/{{site.image}}",
+  {% else %}
+  image: "/static/streamwebs/images/img-default.jpg",
+  {% endif %}
 
   {% language "en-us" %}
   lat: {{site.location.y}},

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -80,7 +80,6 @@ sites.push({
   id: "{{site.id}}",
   slug: "{{site.site_slug}}",
   name: "{{site.site_name}}",
-  description: "{{site.description|escapejs|truncatewords:50}}",
 
   {% language "en-us" %}
   lat: {{site.location.y}},

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -80,7 +80,7 @@ sites.push({
   id: "{{site.id}}",
   slug: "{{site.site_slug}}",
   name: "{{site.site_name}}",
-  description: "{{site.description}}",
+  description: "{{site.description|escapejs}}",
 
   {% language "en-us" %}
   lat: {{site.location.y}},


### PR DESCRIPTION
fixes #515 

## Changes in this PR.
- [x] Escape the site.description for javascript
- [x] Truncate description to 50 words on popups

## Testing this PR.
1. Go to http://localhost:8000/sites/
2. Click on a site

### Expected Output.
You should see the map working properly again and when you click on a site, you should see a truncated description of 50 words or less.

@hertelc I also have this running at http://streamwebs-dev.osuosl.org:8000/ if you want to check yourself.
