### PR TITLE
School search functionality in datasheets and register

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/search_school.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/search_school.js
@@ -1,0 +1,43 @@
+var search_school = function search_school() {
+    var input = $('input#search');
+    if (input.val().length > 0) {
+        $('div.search-results ul li').hide();
+        var searchVal = input.val().toLowerCase();
+        $('div.search-results ul li').each(function() {
+            var val = $(this).find('button').text().toLowerCase();
+            if (val.includes(searchVal)) {
+                $(this).show();
+            }
+        });
+        $('div.search-results').show();
+    }
+}
+
+$(function() {
+    var schoolOptions = $('div.school select option').toArray();
+    for (var i = 0; i < schoolOptions.length; i++) {
+        if (schoolOptions[i].selected === true) {
+            $('p.school-selected b').text(schoolOptions[i].text);
+            break;
+        }
+    }
+    $('div.search-results button').on('click', function(e) {
+        e.preventDefault();
+        var schoolName = $(e.target).text();
+        for (var i = 0; i < schoolOptions.length; i++) {
+            if (schoolOptions[i].text === schoolName) {
+                schoolOptions[i].selected = true;
+                break;
+            }
+        }
+        $('input#search').val(schoolName);
+        $('p.school-selected b').text(schoolName);
+        $('div.search-results').hide();
+    });
+    $(document).on('click', function() {
+        $('div.search-results').hide();
+    });
+    $('input#search').on('input', function() {
+        search_school();
+    });
+});

--- a/streamwebs_frontend/streamwebs/static/streamwebs/style.css
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/style.css
@@ -216,6 +216,38 @@ div#footer-branding img#osu {
     height: 90px;
 }
 
+/* CSS for school search bar */
+
+div.search-results {
+  display: none;
+  width: 100%;
+  top: 64px;
+}
+
+div.search-results ul {
+    max-height: 500px;
+    overflow: scroll;
+}
+
+div.search-results ul li {
+    width: 100%;
+    height: 40px;
+    background: teal;
+    border: 1px gray solid;
+}
+
+div.search-results ul li button {
+    height: 40px;
+    line-height: 40px;
+    width: 100%;
+    color: #03A9F4;
+    background: white;
+    border:none;
+    text-align: left;
+    float: left;
+    padding-left: 10px;
+}
+
 /* CSS for D3 graphs; ALL FREE TO BE CHANGED */
 .graph {
     position: relative;

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/account.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/account.html
@@ -17,7 +17,7 @@
   <br/>
   <div class="row">
     <div class="col offset-s4 s4" style="text-align:center;">
-      <b>Name:{{ user.first_name }} {{ user.last_name }}</b>
+      <b>Name: {{ user.first_name }} {{ user.last_name }}</b>
     </div>
   </div>
   <div class="row">

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
@@ -22,18 +22,46 @@
 
         <p>{{ camera_form.site }}</p>
         <div class="row">
-          <div class="input-field col s12">
+          <div class="col s12">
+            <p class="school-selected">
+              School Selection: <b class="teal-text text-darken-3"></b>
+            </p>
+          </div>
+        </div>
+        <br/><br/>
+        <div class="row">
+          <nav class="search-nav col s6 teal darken-3">
+            <div class="nav-wrapper">
+              <div class="input-field">
+                <input id="search" type="search" autocomplete="off"
+                    placeholder="{% trans 'Search School/Organization' %}">
+                <label for="search"><i class="material-icons">search</i></label>
+                <div class="search-results">
+                  <ul>
+                  {% for school in camera_form.school %}
+                    <li>
+                      <button>
+                        {{ school }}
+                      </button>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <div class="col s6">
+            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+          </div>
+          <div class="input-field school" style="display:none;">
             {{ camera_form.school.label }}
             {{ camera_form.school.errors }}
             {{ camera_form.school }}
           </div>
-          <div class="col s12">
-            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
-          </div>
         </div>
+        <br/>
         <div class="loc-input">
           <!-- CAMERA FORM: -->
-          {{ camera_form.media }}
           <h5>{% trans "Location Input" %}</h5>
           <div class="input-field col s12">
             {% trans "Camera Point Date (YYYY-MM-DD)" %}
@@ -64,9 +92,9 @@
             </div>
             <div class="map" style="height:400px;"></div>
             <input type="hidden" id="input_lat" name="lat"
-                   value="{{ site.to_dict.location.y }}">
+              value="{{ lat }}">
             <input type="hidden" id="input_lng" name="lng"
-                   value="{{ site.to_dict.location.x }}">
+              value="{{ lng }}">
           </div>
           <!-- END CAMERA FORM -->
         </div>
@@ -153,6 +181,8 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/pickadate.js/3.5.6/compressed/picker.date.js"></script>
   <script
       src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+  <script type="application/javascript"
+      src="{% static 'streamwebs/js/search_school.js' %}"></script>
   <script type="application/javascript">
     // initialize curr_marker
     var curr_marker = null;
@@ -165,7 +195,7 @@
           Materialize.toast('{{ message }}', 4000, 'green');
         {% endfor %}
       {% endif %}
-      var latlng = new google.maps.LatLng("{{ site.to_dict.location.y }}", "{{ site.to_dict.location.x }}");
+      var latlng = new google.maps.LatLng("{{ lat }}", "{{ lng }}");
       var mapOptions = {
         zoom: 14,
         center: latlng,
@@ -176,18 +206,17 @@
       map = new google.maps.Map($('.map')[0], mapOptions);
 
       marker = new google.maps.Marker({
-        position: {lat:{{ site.to_dict.location.y }}, lng:{{ site.to_dict.location.x }}},
+        position: {lat:{{ lat }}, lng:{{ lng }}},
         map: map,
         title: "Site Location"
       });
 
-      $('span#lat').text({{ site.to_dict.location.y }});
-      $('span#lng').text({{ site.to_dict.location.x }});
+      $('span#lat').text({{ lat }});
+      $('span#lng').text({{ lng }});
 
       // pass event to function
       map.addListener('click', function(e) {
         placeMarker(e.latLng, map);
-        console.log(e.latLng.lat());
         var lat = e.latLng.lat();
         var lng = e.latLng.lng();
         $('span#lat').text(lat);

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/canopy_cover_edit.html
@@ -68,17 +68,46 @@
     <form id='canopy_cover_form' method='post'>
       {% csrf_token %}
       {{ canopy_cover_form.non_field_errors }}
-
+      <br/><br/>
       <div class="row">
         <div class="col s12">
-          <div class="input-field">
-            {{ canopy_cover_form.school.label }}
-            {{ canopy_cover_form.school.errors }}
-            {{ canopy_cover_form.school }}
-          </div>
-          <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+          <p class="school-selected">
+            School Selection: <b class="teal-text text-darken-3"></b>
+          </p>
         </div>
       </div>
+      <br/>
+      <div class="row">
+        <nav class="search-nav col s6 teal darken-3">
+          <div class="nav-wrapper">
+            <div class="input-field">
+              <input id="search" type="search" autocomplete="off"
+                  placeholder="{% trans 'Search School/Organization' %}">
+              <label for="search"><i class="material-icons">search</i></label>
+              <div class="search-results">
+                <ul>
+                {% for school in canopy_cover_form.school %}
+                  <li>
+                    <button>
+                      {{ school }}
+                    </button>
+                  </li>
+                {% endfor %}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </nav>
+        <div class="col s6">
+          <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+        </div>
+        <div class="input-field school" style="display:none;">
+          {{ canopy_cover_form.school.label }}
+          {{ canopy_cover_form.school.errors }}
+          {{ canopy_cover_form.school }}
+        </div>
+      </div>
+      <br/>
       <div class="row">
         <div class="col s6">
           <div class="input-field">
@@ -339,6 +368,13 @@
 {% endblock %}
 
 {% block scripts %}
+  <script type="application/javascript"
+  src="{% static 'streamwebs/js/search_school.js' %}"></script>
+  <script type="application/javascript"
+          src="{% static 'streamwebs/js/data.js' %}"></script>
+  <script type="application/javascript"
+          src="{% static 'streamwebs/js/data/edit/canopy_cover.js' %}">
+  </script>
   <script>
     var error = '{{ error }}';
     $(document).ready(function() {
@@ -353,10 +389,5 @@
           }
         });
       });
-  </script>
-  <script type="application/javascript"
-          src="{% static 'streamwebs/js/data.js' %}"></script>
-  <script type="application/javascript"
-          src="{% static 'streamwebs/js/data/edit/canopy_cover.js' %}">
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/macroinvertebrate_edit.html
@@ -21,17 +21,46 @@
       <h4 align="center">{% trans 'New Macroinvertebrate Sampling' %}</h4>
       <form id='macro_form' method='post' action='{{ request.path }}'>
         {% csrf_token %}
-
+        <br/><br/>
         <div class="row">
           <div class="col s12">
+            <p class="school-selected">
+              School Selection: <b class="teal-text text-darken-3"></b>
+            </p>
+          </div>
+        </div>
+        <br/>
+        <div class="row">
+          <nav class="search-nav col s6 teal darken-3">
+            <div class="nav-wrapper">
+              <div class="input-field">
+                <input id="search" type="search" autocomplete="off"
+                    placeholder="{% trans 'Search School/Organization' %}">
+                <label for="search"><i class="material-icons">search</i></label>
+                <div class="search-results">
+                  <ul>
+                  {% for school in macro_form.school %}
+                    <li>
+                      <button>
+                        {{ school }}
+                      </button>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <div class="col s6">
+            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+          </div>
+          <div class="input-field school" style="display:none;">
             {{ macro_form.school.label }}
             {{ macro_form.school.errors }}
             {{ macro_form.school }}
           </div>
-          <div class="col s12">
-            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
-          </div>
         </div>
+        <br/>
         <div class="row">
           <div class="col s6">
             {{ macro_form.date.label }} (YYYY-MM-DD)
@@ -156,6 +185,8 @@
 {% endblock %}
 
 {% block scripts %}
+  <script type="application/javascript"
+  src="{% static 'streamwebs/js/search_school.js' %}"></script>
   <script>
     $(document).ready(function() {
       {% if messages %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/rip_aqua_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/rip_aqua_edit.html
@@ -39,17 +39,45 @@
   <h4 align="center">{% trans 'New Riparian and Aquatic Survey' %}</h4>
   <form id="rip_aqua_form" method="post" action="{{ request.path }}">
     {% csrf_token %}
-
+    <br/><br/>
     <div class="row">
       <div class="col s12">
+        <p class="school-selected">
+          School Selection: <b class="teal-text text-darken-3"></b>
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <nav class="search-nav col s6 teal darken-3">
+        <div class="nav-wrapper">
+          <div class="input-field">
+            <input id="search" type="search" autocomplete="off"
+                placeholder="{% trans 'Search School/Organization' %}">
+            <label for="search"><i class="material-icons">search</i></label>
+            <div class="search-results">
+              <ul>
+              {% for school in rip_aqua_form.school %}
+                <li>
+                  <button>
+                    {{ school }}
+                  </button>
+                </li>
+              {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </nav>
+      <div class="col s6">
+        <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+      </div>
+      <div class="input-field school" style="display:none;">
         {{ rip_aqua_form.school.label }}
         {{ rip_aqua_form.school.errors }}
         {{ rip_aqua_form.school }}
       </div>
-      <div class="col s12">
-        <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
-      </div>
     </div>
+    <br/>
     <div class="row">
       <div class="col s6">
         {{ rip_aqua_form.date.label }} (YYYY-MM-DD)
@@ -425,7 +453,8 @@
 
 {% block scripts %}
   <script type="application/javascript" src="{% static 'streamwebs/js/data.js' %}"></script>
-
+  <script type="application/javascript"
+  src="{% static 'streamwebs/js/search_school.js' %}"></script>
   <script type="text/javascript">
   window.addEventListener('keydown',function(e){
     if(e.keyIdentifier=='U+000A'||e.keyIdentifier=='Enter'||e.keyCode==13){

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/riparian_transect_edit.html
@@ -20,126 +20,151 @@
         {% endfor %}
       </div>
     {% endif %}
+    <h3 align="center" class="teal-text">
+      {{ site.site_name }}
+    </h3>
 
-    {% if added %}
-      <strong>{% trans "You have successfully submitted your Riparian Transect data sheet." %}</strong>
-    {% else %}
-      <h3 align="center" class="teal-text">
-        {{ site.site_name }}
-      </h3>
+    <h4 align="center">{% trans 'New Riparian Area Transect Sampling' %}</h4>
 
-      <h4 align="center">{% trans 'New Riparian Area Transect Sampling' %}</h4>
-
-      <form id='rip_trans_form' method='post'>
-        {% csrf_token %}
-        <tr>{{ transect_form.non_field_errors }}</tr>
-
-        <div class="row">
+    <form id='rip_trans_form' method='post'>
+      {% csrf_token %}
+      <tr>{{ transect_form.non_field_errors }}</tr>
+      <br/><br/>
+      <div class="row">
+        <div class="col s12">
+          <p class="school-selected">
+            School Selection: <b class="teal-text text-darken-3"></b>
+          </p>
+        </div>
+      </div>
+      <br/>
+      <div class="row">
+        <nav class="search-nav col s6 teal darken-3">
+          <div class="nav-wrapper">
+            <div class="input-field">
+              <input id="search" type="search" autocomplete="off"
+                  placeholder="{% trans 'Search School/Organization' %}">
+              <label for="search"><i class="material-icons">search</i></label>
+              <div class="search-results">
+                <ul>
+                {% for school in transect_form.school %}
+                  <li>
+                    <button>
+                      {{ school }}
+                    </button>
+                  </li>
+                {% endfor %}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </nav>
+        <div class="col s6">
+          <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+        </div>
+        <div class="input-field school" style="display:none;">
+          {{ transect_form.school.label }}
+          {{ transect_form.school.errors }}
+          {{ transect_form.school }}
+        </div>
+      </div>
+      <br/>
+      <div class="row">
+        <div class="col s6">
           <div class="input-field">
-            {{ transect_form.school.label }}
-            {{ transect_form.school.errors }}
-            {{ transect_form.school }}
+            {{ transect_form.date.label }} (YYYY-MM-DD)
+            {{ transect_form.date.errors }}
+            {{ transect_form.date }}
           </div>
         </div>
-        <div class="row">
-          <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
-        </div>
-
-        <div class="row">
-          <div class="col s6">
-            <div class="input-field">
-              {{ transect_form.date.label }} (YYYY-MM-DD)
-              {{ transect_form.date.errors }}
-              {{ transect_form.date }}
-            </div>
-          </div>
-          <div class="col s3">
-            <div class="input-field">
-              {{ transect_form.time.label }} (HH:MM)
-              {{ transect_form.time.errors}}
-              {{ transect_form.time }}
-            </div>
-          </div>
-          <div class="col s3">
-            <div class="input-field">
-              {{ transect_form.ampm.label }}
-              {{ transect_form.ampm.errors }}
-              {{ transect_form.ampm }}
-            </div>
-          </div>
-          <div class="col s6">
-            <div class="input-field">
-              {{ transect_form.weather.label }}
-              {{ transect_form.weather.errors }}
-              {{ transect_form.weather }}
-            </div>
-          </div>
-        </div>
-
-        <div class="row">
+        <div class="col s3">
           <div class="input-field">
-            {{ transect_form.slope.label }}
-            {{ transect_form.slope.errors }}
-            {{ transect_form.slope }}
+            {{ transect_form.time.label }} (HH:MM)
+            {{ transect_form.time.errors}}
+            {{ transect_form.time }}
           </div>
         </div>
+        <div class="col s3">
+          <div class="input-field">
+            {{ transect_form.ampm.label }}
+            {{ transect_form.ampm.errors }}
+            {{ transect_form.ampm }}
+          </div>
+        </div>
+        <div class="col s6">
+          <div class="input-field">
+            {{ transect_form.weather.label }}
+            {{ transect_form.weather.errors }}
+            {{ transect_form.weather }}
+          </div>
+        </div>
+      </div>
 
-        <br>
-        <div class="divider"></div>
-        <br>
+      <div class="row">
+        <div class="input-field">
+          {{ transect_form.slope.label }}
+          {{ transect_form.slope.errors }}
+          {{ transect_form.slope }}
+        </div>
+      </div>
 
-        {{ zone_formset.management_form }}
-        <table> <!-- zones subtable -->
-          <tr>{{ zone_formset.non_form_errors }}</tr>
+      <br>
+      <div class="divider"></div>
+      <br>
+
+      {{ zone_formset.management_form }}
+      <table> <!-- zones subtable -->
+        <tr>{{ zone_formset.non_form_errors }}</tr>
+        <tr>
+          <th>{{ 'zone'|get_zone_labels }}</th>
+          <th>{{ 'conifers'|get_zone_labels }}</th>
+          <th>{{ 'hardwoods'|get_zone_labels }}</th>
+          <th>{{ 'shrubs'|get_zone_labels }}</th>
+          <th>{{ 'comments'|get_zone_labels }}</th>
+        </tr>
+        {% for zone_form in zone_formset %}
           <tr>
-            <th>{{ 'zone'|get_zone_labels }}</th>
-            <th>{{ 'conifers'|get_zone_labels }}</th>
-            <th>{{ 'hardwoods'|get_zone_labels }}</th>
-            <th>{{ 'shrubs'|get_zone_labels }}</th>
-            <th>{{ 'comments'|get_zone_labels }}</th>
+            <th>
+              {{ forloop.counter0|plus_one }}<br>
+              {{ forloop.counter0|get_zone }}
+            </th>
+            <td>{{ zone_form.conifers }}</td>
+            <td>{{ zone_form.hardwoods }}</td>
+            <td>{{ zone_form.shrubs }}</td>
+            <td>{{ zone_form.comments }}</td>
           </tr>
-          {% for zone_form in zone_formset %}
-            <tr>
-              <th>
-                {{ forloop.counter0|plus_one }}<br>
-                {{ forloop.counter0|get_zone }}
-              </th>
-              <td>{{ zone_form.conifers }}</td>
-              <td>{{ zone_form.hardwoods }}</td>
-              <td>{{ zone_form.shrubs }}</td>
-              <td>{{ zone_form.comments }}</td>
-            </tr>
-            <tr>
-              <th></th>
-              <td>{{ zone_form.conifers.errors }}</td>
-              <td>{{ zone_form.hardwoods.errors }}</td>
-              <td>{{ zone_form.shrubs.errors }}</td>
-              <td>{{ zone_form.comments.errors }}</td>
-            </tr>
-          {% endfor %}
-        </table> <!-- end zones subtable -->
+          <tr>
+            <th></th>
+            <td>{{ zone_form.conifers.errors }}</td>
+            <td>{{ zone_form.hardwoods.errors }}</td>
+            <td>{{ zone_form.shrubs.errors }}</td>
+            <td>{{ zone_form.comments.errors }}</td>
+          </tr>
+        {% endfor %}
+      </table> <!-- end zones subtable -->
 
-        <div class="divider"></div>
-        <br>
+      <div class="divider"></div>
+      <br>
 
-        <div class="row">
-          <div class="input-field">
-            {{ transect_form.notes.label }}
-            {{ transect_form.notes.errors }}
-            {{ transect_form.notes }}
-          </div>
+      <div class="row">
+        <div class="input-field">
+          {{ transect_form.notes.label }}
+          {{ transect_form.notes.errors }}
+          {{ transect_form.notes }}
         </div>
+      </div>
 
-        <button class="btn wave-effect waves-light teal darken-3" type="submit"
-          name="submit" value="{% trans "Submit" %}">
-          {% trans "Submit" %}
-        </button>
-      </form>
-    {% endif %}
+      <button class="btn wave-effect waves-light teal darken-3" type="submit"
+        name="submit" value="{% trans "Submit" %}">
+        {% trans "Submit" %}
+      </button>
+    </form>
   </div>
 {% endblock %}
 
 {% block scripts %}
+  <script type="application/javascript"
+  src="{% static 'streamwebs/js/search_school.js' %}"></script>
   <script>
   $(document).ready(function() {
     {% if messages %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_edit.html
@@ -23,19 +23,46 @@
       <h4 align="center">{% trans "New Riparian Soil Survey" %}</h4>
       <form id='soil_form' method='post' action='{{ request.path }}'>
         {% csrf_token %}
-        <br/>
+        <br/><br/>
         <div class="row">
           <div class="col s12">
+            <p class="school-selected">
+              School Selection: <b class="teal-text text-darken-3"></b>
+            </p>
+          </div>
+        </div>
+        <br/>
+        <div class="row">
+          <nav class="search-nav col s6 teal darken-3">
+            <div class="nav-wrapper">
+              <div class="input-field">
+                <input id="search" type="search" autocomplete="off"
+                    placeholder="{% trans 'Search School/Organization' %}">
+                <label for="search"><i class="material-icons">search</i></label>
+                <div class="search-results">
+                  <ul>
+                  {% for school in soil_form.school %}
+                    <li>
+                      <button>
+                        {{ school }}
+                      </button>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <div class="col s6">
+            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+          </div>
+          <div class="input-field school" style="display:none;">
             {{ soil_form.school.label }}
             {{ soil_form.school.errors }}
             {{ soil_form.school }}
           </div>
         </div>
-        <div class="row">
-          <div class="col s12">
-            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
-          </div>
-        </div>
+        <br/>
         <div class="row">
           <div class="col s6">
             {{ soil_form.date.label }} (YYYY-MM-DD)
@@ -139,7 +166,8 @@
 {% endblock %}
 
 {% block scripts %}
-
+  <script type="application/javascript"
+  src="{% static 'streamwebs/js/search_school.js' %}"></script>
   <script>
   $(document).ready(function() {
     {% if messages %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/soil_view.html
@@ -13,7 +13,7 @@
   </a>
   <div class="container">
     {% if messages %}
-      <div class="messages">
+      <div class="center-content">
         {% for message in messages %}
           <strong>{{ message }}</strong>
         {% endfor %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality_edit.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/water_quality_edit.html
@@ -28,16 +28,46 @@
       {% csrf_token %}
       <div class="infogroup">
         <p>{{ wq_form.site.errors }}</p>
+        <br/><br/>
         <div class="row">
           <div class="col s12">
-            <div class="input-field">
-              {{ wq_form.school.label }}
-              {{ wq_form.school.errors }}
-              {{ wq_form.school }}
-            </div>
-            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+            <p class="school-selected">
+              School Selection: <b class="teal-text text-darken-3"></b>
+            </p>
           </div>
         </div>
+        <br/><br/>
+        <div class="row">
+          <nav class="search-nav col s6 teal darken-3">
+            <div class="nav-wrapper">
+              <div class="input-field">
+                <input id="search" type="search" autocomplete="off"
+                    placeholder="{% trans 'Search School/Organization' %}">
+                <label for="search"><i class="material-icons">search</i></label>
+                <div class="search-results">
+                  <ul>
+                  {% for school in wq_form.school %}
+                    <li>
+                      <button>
+                        {{ school }}
+                      </button>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <div class="col s6">
+            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+          </div>
+          <div class="input-field school" style="display:none;">
+            {{ wq_form.school.label }}
+            {{ wq_form.school.errors }}
+            {{ wq_form.school }}
+          </div>
+        </div>
+        <br/>
         <div class="row">
           <div class="col s6">
             <div class="input-field">
@@ -470,6 +500,8 @@ $(document).ready(function() {
 </script>
 <script type="application/javascript"
 src="{% static 'streamwebs/js/data.js' %}"></script>
+<script type="application/javascript"
+src="{% static 'streamwebs/js/search_school.js' %}"></script>
 <script>
 var radioFields = [];
 radioFields.push({name: 'if there are any fish present', val: $('div.fish-presence input')});

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/register.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/register.html
@@ -168,6 +168,11 @@
             max: true, // set max to today
             format: 'yyyy-mm-dd',
         });
+        $("form").bind("keypress", function(e) {
+          if (e.keyCode == 13){
+            return false;
+          }
+        });
       });
   </script>
 {% endblock %}

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/register.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/register.html
@@ -1,5 +1,6 @@
 {% extends 'streamwebs/base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block title %}{% trans "Register" %} -{% endblock %}
 
@@ -54,12 +55,45 @@
             {{ profile_form.birthdate.errors }}
           </div>
 
-          <div class="input-field col s12 ">
-            {{ profile_form.school }}
-            {{ profile_form.school.errors }}
-            <label for="{{ profile_form.school.id_for_label }}">{% trans "School" %}:</label>
-            <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+          <div class="row">
+            <div class="col s12">
+              <p class="school-selected">
+                School Selection: <b class="teal-text text-darken-3"></b>
+              </p>
+            </div>
           </div>
+          <div class="row">
+            <nav class="search-nav col s12 teal darken-3">
+              <div class="nav-wrapper">
+                <div class="input-field">
+                  <input id="search" type="search" autocomplete="off"
+                      placeholder="{% trans 'Search School/Organization' %}">
+                  <label for="search"><i class="material-icons">search</i></label>
+                  <div class="search-results">
+                    <ul>
+                    {% for school in profile_form.school %}
+                      <li>
+                        <button>
+                          {{ school }}
+                        </button>
+                      </li>
+                    {% endfor %}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </nav>
+            <br/><br/><br/><br/>
+            <div class="col s12">
+              <a href="{% url 'streamwebs:create_school' %}?next={{ request.path|urlencode }}" class="btn-large waves-effect waves-light teal darken-3">{% trans "Add A School/Organization" %}</a>
+            </div>
+            <div class="input-field school" style="display:none;">
+              {{ profile_form.school.label }}
+              {{ profile_form.school.errors }}
+              {{ profile_form.school }}
+            </div>
+          </div>
+          <br/>
 
           <div class="input-field col s12">
             <label
@@ -117,6 +151,8 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/pickadate.js/3.5.6/compressed/picker.date.js"></script>
   <script
       src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+  <script type="application/javascript"
+      src="{% static 'streamwebs/js/search_school.js' %}"></script>
   <script>
       $(document).ready(function () {
         {% if messages %}

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -885,6 +885,8 @@ def add_camera_point(request, site_slug):
         form=PhotoPointImageForm,
         extra=1, max_num=1, min_num=1                 # one PPI for each PP
     )
+    lat = site.location.y
+    lng = site.location.x
 
     if request.method == 'POST':
         if not request.POST._mutable:
@@ -896,9 +898,11 @@ def add_camera_point(request, site_slug):
 
         # convert lat and longs into a pointfield object
         point = ("SRID=4326;POINT(%s %s)" %
-                 (request.POST['lat'], request.POST['lng']))
+                 (request.POST['lng'], request.POST['lat']))
         # spoof the location and  request param with the point object
         # and proceed like normal.
+        lat = request.POST['lat']
+        lng = request.POST['lng']
         request.POST['location'] = point
         request.POST['site'] = site.id
 
@@ -947,6 +951,8 @@ def add_camera_point(request, site_slug):
     return render(
         request,
         'streamwebs/datasheets/camera_point_add.html', {
+            'lat': lat,
+            'lng': lng,
             'camera_form': camera_form,
             'pp_formset': pp_formset,
             'ppi_formset': ppi_formset,


### PR DESCRIPTION
fixes issue #487 

## Changes in this PR.

- [X] Implement the search school functionality in all datasheets. all in a .js file
- [X] Corrected camera point coordinate format when posting data, to match the ones from drupal.
- [X] Errors on form does not make the school selection return to default

## Testing this PR.

Sites to be tested: add macroinvertebrate, camera_point, canopy_cover, rip_aqua, rip_trans, soil, water_quality, and register.html
For each site do the following:
1. search for a school: click on the school you'd like to select. Make sure the highlighted school name in "school selection: " is the school you'd like to select. Complete the form and submit, make sure the school name is correct.
2. search for a school, rather than submitting a good form, create an intentional error.
(easiest way: for most datasheets, fill invalid data for time field, ex: "12:123", or for integer field, enter a very large integer that is more than a trillion, or for register.html, select your birth date as today, which will trigger an error since user has to be at least 13 years old.
3. This time, for the same site, don't search for a school. complete the form and submit. After submission make sure the school is the default school, which is the first school in alphabetical order.

### Expected Output.

Everything works, reference above for expected output.

```
$ make test
[... test output ...]
```

@osuosl/devs
