### PR TITLE
Improve docker-compose environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ install:
   - bower install
 
 script:
-  - flake8 data_scripts
-  - flake8 streamwebs_frontend/ --exclude streamwebs_frontend/streamwebs/migrations
   - ./runtests.sh
 
 addons:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # StreamWebs
-[![Build Status](https://travis-ci.org/osuosl/streamwebs.svg?branch=develop)]
-(https://travis-ci.org/osuosl/streamwebs)
+[![Build Status](https://travis-ci.org/osuosl/streamwebs.svg?branch=develop)](https://travis-ci.org/osuosl/streamwebs)
 
 This repository will be used to help track issues and share files for the 
 existing Streamwebs site during the transition to a possible re-write of the 

--- a/README.md
+++ b/README.md
@@ -1,58 +1,46 @@
 # StreamWebs
 [![Build Status](https://travis-ci.org/osuosl/streamwebs.svg?branch=develop)](https://travis-ci.org/osuosl/streamwebs)
 
-This repository will be used to help track issues and share files for the 
-existing Streamwebs site during the transition to a possible re-write of the 
-application.
+This repository will be used to help track issues and share files for the existing Streamwebs site during the
+transition to a possible re-write of the application.
 
-To set up a dev instance of StreamWebs, copy ``Dockerfile.env.dist`` to 
-``Dockerfile.env``. You will also have to copy ``settings.py.dist`` to
-``settings.py`` (located in ``streamwebs_frontend/streamwebs_frontend``). Then,
-run the following:
-```
+To set up a dev instance of StreamWebs, copy ``Dockerfile.env.dist`` to ``Dockerfile.env``. You will also have to copy
+``settings.py.dist`` to ``settings.py`` (located in ``streamwebs_frontend/streamwebs_frontend``). Then, run the
+following:
+
+``` console
 $ docker-compose build
 $ docker-compose up
 ```
 
-The following is a list of the more common and more useful docker commands: 
-- ``docker-compose build`` will build the necessary containers 
-- ``docker-compose build --no-cache --pull`` does a full from-scratch build;
-  you can run this when the changes made to the docker environment are not
-taking effect 
+The following is a list of the more common and more useful docker commands:
+
+- ``docker-compose build`` will build the necessary containers
+- ``docker-compose build --no-cache --pull`` does a full from-scratch build; you can run this when the changes made to
+  the docker environment are not taking effect.
 - ``docker-compose up`` runs the application
-- ``docker-compose run web bash`` is like docker-compose up but also provides
-  an interactive shell
-- ``docker-compose run --service-ports --rm web bash`` exposes the ports
-  described for the web service and removes the container upon completion
+- ``docker-compose run web bash`` is like docker-compose up but also provides an interactive shell
+- ``docker-compose run --service-ports --rm web bash`` exposes the ports described for the web service and removes the
+  container upon completion
 - `docker-compose kill` stops services that are running
-- `docker-compose rm` removes all the containers associated with the
-  application's services
+- `docker-compose rm` removes all the containers associated with the application's services
 - `docker-compose ps` lists all the running containers
 
-
-**Note that docker-compose and docker commands may need to be run as root with
-the ``sudo`` prefix.**
-
-If you run into this error:
-```
-ERROR: stat /home/thai/projects/streamwebs: too many levels of symbolic links
-```
-restarting docker should fix the problem. The command to do so is
-``sudo systemctl restart docker``
-
-
-Another note: after running ``docker-compose up``, docker doesn't print the
-standard "django app is running" output. Just know that it is.
-
-You can check that this is true by going to ``localhost:8000/streamwebs`` in
-your browser.
-
+After running ``docker-compose up``, docker doesn't print the standard "django app is running" output. Instead, just go
+to http://localhost:8000 instead.
 
 ### Miscellaneous Tips
-Run ``flake8 streamwebs_frontend --exclude streamwebs_frontend/streamwebs/migrations``
-to exclude the migrations directory when linting.
 
-If you'd like to access the postgresql database, open up an interactive shell
-with ``docker-compose run web bash``. Then run the following command:
-``psql -h $POSTGRES_HOST -d streamwebs -U $POSTGRES_USER. This will bring you
-to the postgres interactive terminal.
+Run ``flake8 streamwebs_frontend --exclude streamwebs_frontend/streamwebs/migrations`` to exclude the migrations
+directory when linting.
+
+If you'd like to access the postgresql database, open up an interactive shell with ``docker-compose run web bash``.
+Then run the following command: ``PGPASSWORD=$POSTGRES_PASSWORD psql -h postgres_host -U $POSTGRES_USER streamwebs``.
+This will bring you to the postgres interactive terminal. You can also do get access running ``python
+streamwebs_frontend/manage.py dbshell``.
+
+If you would like to drop the ``streamwebs`` database each time the web container runs, add ``STREAMWEBS_DROP=1`` to
+your ``Dockerfile.env`` file.
+
+If you would like to only run tests, add ``STREAMWEBS_TEST=1`` to your `Dockerfile.env`` file. Keep in mind this
+doesn't run the djange web server and only runs the tests.

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ your ``Dockerfile.env`` file.
 If you would like to only run tests, add ``STREAMWEBS_TEST=1`` to your ``Dockerfile.env`` file. Keep in mind this
 doesn't run the django web server and only runs the tests.
 
-If you want to automatically import the CSV data, you need to add both `STREAMWEBS_DROP=1`` and
+If you want to automatically import the CSV data, you need to add both ``STREAMWEBS_DROP=1`` and
 ``STREAMWEBS_IMPORT_DATA=1`` to your ``Dockerfile.env`` file.

--- a/README.md
+++ b/README.md
@@ -42,5 +42,8 @@ streamwebs_frontend/manage.py dbshell``.
 If you would like to drop the ``streamwebs`` database each time the web container runs, add ``STREAMWEBS_DROP=1`` to
 your ``Dockerfile.env`` file.
 
-If you would like to only run tests, add ``STREAMWEBS_TEST=1`` to your `Dockerfile.env`` file. Keep in mind this
-doesn't run the djange web server and only runs the tests.
+If you would like to only run tests, add ``STREAMWEBS_TEST=1`` to your ``Dockerfile.env`` file. Keep in mind this
+doesn't run the django web server and only runs the tests.
+
+If you want to automatically import the CSV data, you need to add both `STREAMWEBS_DROP=1`` and
+``STREAMWEBS_IMPORT_DATA=1`` to your ``Dockerfile.env`` file.

--- a/dockerfiles/Dockerfile.env.dist
+++ b/dockerfiles/Dockerfile.env.dist
@@ -2,3 +2,9 @@ POSTGRES_DB=streamwebs
 POSTGRES_USER=postgres_user
 POSTGRES_PASSWORD=postgres_pw
 PYTHONUNBUFFERED=0
+# Drop streamwebs database
+# STREAMWEBS_DROP=1
+# Only run tests
+# STREAMWEBS_TEST=1
+# Import CSV data (requires STREAMWEBS_DROP=1)
+# STREAMWEBS_IMPORT_DATA=1

--- a/dockerfiles/cleanup.sh
+++ b/dockerfiles/cleanup.sh
@@ -1,1 +1,1 @@
-chown --reference=/opt/streamwebs -R .
+[ -d /opt/streamwebs ] && chown --reference=/opt/streamwebs -R .

--- a/dockerfiles/startup.sh
+++ b/dockerfiles/startup.sh
@@ -20,5 +20,11 @@ if [ -n "$STREAMWEBS_TEST" ] ; then
 else
   yes "yes" | python /home/centos/streamwebs/streamwebs_frontend/manage.py migrate
   echo "from django.contrib.auth.models import User; User.objects.filter(email='streamwebs@osuosl.org').delete(); User.objects.create_superuser('admin', 'streamwebs@osuosl.org', 'admin')" | python streamwebs_frontend/manage.py shell
+  if [ -n "$STREAMWEBS_IMPORT_DATA" -a -n "$STREAMWEBS_DROP" ] ; then
+    echo "Importing data.."
+    cd data_scripts/
+    ./get_all.sh
+    cd ../
+  fi
   python /home/centos/streamwebs/streamwebs_frontend/manage.py runserver 0.0.0.0:8000
 fi

--- a/dockerfiles/startup.sh
+++ b/dockerfiles/startup.sh
@@ -2,6 +2,12 @@
 
 trap /home/centos/streamwebs/dockerfiles/cleanup.sh EXIT
 bower install --allow-root
+export PGPASSWORD=$POSTGRES_PASSWORD
+echo "Waiting for postgres to start.."
+until $(psql -h postgres_host -U $POSTGRES_USER streamwebs \
+  -c 'SELECT PostGIS_full_version();' 2> /dev/null | grep -q POSTGIS) ; do
+	sleep 1
+done
 yes "yes" | python /home/centos/streamwebs/streamwebs_frontend/manage.py migrate
 echo "from django.contrib.auth.models import User; User.objects.filter(email='streamwebs@osuosl.org').delete(); User.objects.create_superuser('admin', 'streamwebs@osuosl.org', 'admin')" | python streamwebs_frontend/manage.py shell
 python /home/centos/streamwebs/streamwebs_frontend/manage.py runserver 0.0.0.0:8000

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+set -x
+# lint tests
+flake8 data_scripts
+flake8 streamwebs_frontend/ --exclude streamwebs_frontend/streamwebs/migrations
 
 # run migrations then test
 python streamwebs_frontend/manage.py makemigrations


### PR DESCRIPTION
This applies a few enhancements and fixes for the docker-compose development environment.

## Changes in this PR.
- [x] The ``web`` container properly waits until the ``postgres_host`` is ready before running migrations \o/
- [x] Add ``STREAMWEBS_DROP`` environment variable which will drop the streamwebs database. Useful if you're needing to do migration tests.
- [x] Add ``STREAMWEBS_TEST`` which will only run the same tests that travis would run
- [x] Add ``STREAMWEBS_IMPORT_DATA`` which will run ``./get_all.sh`` to help with testing CSV data.
- [x] Move all tests for Travis in ``runtests.sh`` so it can also be run in docker if needed.
- [x] Fix the build status URL (finally!)
- [x] Update the documentation a bit

## Testing this PR.
1. ``docker-compose kill && docker-compose rm --all -f``
1. ``docker-compose up`` -- this should run without any issue

Keep in mind to remove the setting var after each test for below:

### Dropping databases
1. Add `` STREAMWEBS_DROP=1`` to ``dockerfiles/Dockerfile.env``
1. ``docker-compose stop web && docker-compose up web`` should now drop the database and run migrations again

### Running tests only
1. Add `` STREAMWEBS_TEST=1`` to ``dockerfiles/Dockerfile.env``
1. ``docker-compose stop web && docker-compose up web`` should now only run tests

### Importing data
1. Add `` STREAMWEBS_DROP=1`` and ``STREAMWEBS_IMPORT_DATA=1`` to ``dockerfiles/Dockerfile.env``
1. ``docker-compose stop web && docker-compose up web`` should now drop the database and import the CSV data

### Expected Output.

It should all work! \o/