### PR TITLE
Use https for all google api content

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/base.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/base.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css?family=Lato:400,700|Montserrat" rel="stylesheet">
   <link rel="stylesheet" type="text/css"
         href="{% static 'streamwebs/bower_components/materialize/dist/css/materialize.css' %}"/>
-  <link href="http://fonts.googleapis.com/icon?family=Material+Icons"
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
         rel="stylesheet">
   <link rel="stylesheet" type="text/css"
         href="{% static 'streamwebs/style.css' %}"/>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/create_site.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/create_site.html
@@ -3,7 +3,7 @@
 {% load staticfiles %}
 
 {% block scripts %}
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
 <script type="application/javascript" src="{% static 'streamwebs/js/create_site.js' %}"></script>
 <script>
 var markers = [];

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_add.html
@@ -144,7 +144,7 @@
 
 {% block scripts %}
   <script type="application/javascript"
-          src="http://maps.google.com/maps/api/js?key=AIzaSyBV71HBuAFMtHEAaSEVpRDPUQyGvJwTX1k"></script>
+          src="https://maps.google.com/maps/api/js?key=AIzaSyBV71HBuAFMtHEAaSEVpRDPUQyGvJwTX1k"></script>
   <script
       src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
   <script

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_view.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/datasheets/camera_point_view.html
@@ -143,7 +143,7 @@
 {% block scripts %}
 
   <script type="text/javascript"
-          src="http://maps.google.com/maps/api/js?key=AIzaSyBV71HBuAFMtHEAaSEVpRDPUQyGvJwTX1k"></script>
+          src="https://maps.google.com/maps/api/js?key=AIzaSyBV71HBuAFMtHEAaSEVpRDPUQyGvJwTX1k"></script>
   <script
       src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
   <script>

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/sites.html
@@ -70,7 +70,7 @@
 
 {% block scripts %}
 <script src="https://maps.googleapis.com/maps/api/js?key={{ maps_api }}"></script>
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
 
 <script type="application/javascript">
 window.mapTypeId = {{ map_type }};

--- a/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/update_site.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block scripts %}
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?key={{ maps_api }}"></script>
 <script>
 var map;
 var markers = [];


### PR DESCRIPTION
This should resolve mixed content warnings when using the site over https. This
is related to #546. Hopefully I found all situations where this is happening!

## Changes in this PR.
- [X] Replace all http java script references to https

## Testing this PR.

**Testing this PR will be difficult since it requires a fully functioning SSL pathway. It's best to test this first on staging once deployed.**

1. Open each url below and open up the developer console for your browser
2. You should not see any warnings about mixed content from our browser

- https://streamwebs-staging.osuosl.org/
- https://streamwebs-staging.osuosl.org/sites/
- https://streamwebs-staging.osuosl.org/sites/new/
- https://streamwebs-staging.osuosl.org/sites/se-belmont/edit/
- https://streamwebs-staging.osuosl.org/sites/se-belmont/camera/edit/
- https://streamwebs-staging.osuosl.org/sites/se-belmont/camera/1812/

### Expected Output.

You should not see any mixed content warnings.