### PR TITLE
Disable editor access migration

### DIFF
--- a/streamwebs_frontend/streamwebs/migrations/0035_editor_access.py
+++ b/streamwebs_frontend/streamwebs/migrations/0035_editor_access.py
@@ -20,11 +20,11 @@ def give_editor_access(apps, schema_editor):
         user.save()
 
 class Migration(migrations.Migration):
-
+    '''This migration was temporary for the Jan 6th workshop'''
     dependencies = [
         ('streamwebs', '0034_macro_totals'),
     ]
 
     operations = [
-        migrations.RunPython(give_editor_access)
+        #migrations.RunPython(give_editor_access)
     ]


### PR DESCRIPTION
This PR disables the editor access migration (0035_editor_access.py) to avoid setting all users to editor access should the production system have migration run on it again.

This migration probably should have been a stand alone file that was manually run on production, but instead it made it into the develop branch.