### PR TITLE
(bugfix/statsfix) When user selects today for stats, it now shows the stats from the day.

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/admin/stats.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/admin/stats.html
@@ -6,6 +6,11 @@
 {% block body_title %}{% trans "StreamWebs Statistics" %}{% endblock %}
 
 {% block content %}
+<style>
+  .container li{
+    margin-left: 50px;
+  }
+</style>
   <div class="container">
     <form id='stats_form' method='post'>
         {% csrf_token %}
@@ -32,30 +37,46 @@
 
     {% if all_time %}
         {% trans "Users who have logged in within the last 3 years" %}:
-        {{ users.count }}
+        {{ users.count }} </br>
     {% else %}
-        {% trans "Users who joined between" %} {{ start }} {% trans "and" %} {{ end }}:
+        {% if sameday %}
+          {% trans "Users who joined between" %} {{ start }} {% trans "and" %} {{ today }}:
+        {% else %}
+          {% trans "Users who joined between" %} {{ start }} {% trans "and" %} {{ end }}:
+        {% endif %}
         {{ users.count }}
     {% endif %}
 
     {% for user in users.users %}
         <li>{{ user.username }}</li>
     {% endfor %}
-
-    {% trans "Number of data sheets uploaded between" %} {{ start }} {% trans "and" %} {{ end }}:
+    </br>
+    {% if sameday %}
+      {% trans "Number of data sheets uploaded between" %} {{ start }} {% trans "and" %} {{ today }}:
+    {% else %}
+      {% trans "Number of data sheets uploaded between" %} {{ start }} {% trans "and" %} {{ end }}:
+    {% endif %}
 
     {% for type, num in sheets.items %}
         <li> {{ type }}: {{ num }}</li>
     {% endfor %}
 
-    {% trans "Schools that uploaded data between" %} {{ start }} {% trans "and" %} {{ end }}:
+    </br>
+    {% if sameday %}
+      {% trans "Schools that uploaded data between" %} {{ start }} {% trans "and" %} {{ today }}:
+    {% else %}
+      {% trans "Schools that uploaded data between" %} {{ start }} {% trans "and" %} {{ end }}:
+    {% endif %}
     {{ schools.total }}
-
     {% for school in schools.schools %}
         <li> {{ school.name }} </li>
     {% endfor %}
-
-    {% trans "Sites that uploaded data between" %} {{ start }} {% trans "and" %} {{ end }}:
+    </br>
+    {% if sameday %}
+      {% trans "Sites that uploaded data between" %} {{ start }} {% trans "and" %} {{ today }}:
+    {% else %}
+      {% trans "Sites that uploaded data between" %} {{ start }} {% trans "and" %} {{ end }}:
+    {% endif %}
     {{ sites.total }}
 
     {% for site in sites.sites %}

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -1492,6 +1492,7 @@ def admin_site_statistics(request):
     user_start = datetime.date(today.year - 3, today.month, today.day + 1)
     start = datetime.date(1970, 1, 1)
     end = today
+    sameday = True
 
     if request.method == 'POST':
         stats_form = StatisticsForm(data=request.POST)

--- a/streamwebs_frontend/streamwebs/views/general.py
+++ b/streamwebs_frontend/streamwebs/views/general.py
@@ -1488,7 +1488,7 @@ def admin_site_statistics(request):
 
     # A user is defined as "active" if they have logged in w/in the last 3 yrs
     today = datetime.date.today()
-    user_start = datetime.date(today.year - 3, today.month, today.day)
+    user_start = datetime.date(today.year - 3, today.month, today.day + 1)
     start = datetime.date(1970, 1, 1)
     end = today
 
@@ -1496,6 +1496,7 @@ def admin_site_statistics(request):
         stats_form = StatisticsForm(data=request.POST)
 
         if stats_form.is_valid():
+            print(stats_form)
             # At least one date provided:
             if (stats_form.cleaned_data['start'] is not None or
                     stats_form.cleaned_data['end'] is not None):
@@ -1506,7 +1507,13 @@ def admin_site_statistics(request):
                 # end date provided:
                 if stats_form.cleaned_data['end'] is not None:
                     end = stats_form.cleaned_data['end']
-
+                if end == today:
+                    sameday = True
+                    end += datetime.timedelta(days=1)
+                else:
+                    sameday = False
+                print(today)
+                print(end)
                 users = User.objects.filter(date_joined__range=(start, end))
             else:
                 users = User.objects.filter(
@@ -1574,6 +1581,8 @@ def admin_site_statistics(request):
         'schools': {'total': len(all_schools), 'schools': all_schools},
         'start': start,
         'end': end,
+        'sameday': sameday,
+        'today': today
         }
     )
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #624 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] When selecting today as the "end date" for the stats page, today is now included in the stats.
- [X] Also, I couldn't stand the list view on the page so I made some minor HTML/CSS tweaks to make it look nice

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Navigate to the stats page. 
2. Select today
3. See results from today as well.
4. Enjoy the fancy lists.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ make test
[... test output ...]
```

@osuosl/devs
