### PR TITLE
removed educator kits and upload resource

### DIFF
--- a/streamwebs_frontend/streamwebs/templates/streamwebs/resources.html
+++ b/streamwebs_frontend/streamwebs/templates/streamwebs/resources.html
@@ -136,22 +136,6 @@
         </div>
       </div>
     </a>
-    <a class="resource-link"href="http://extension.oregonstate.edu/benton/educational-kits-and-curriculum" target="_blank">
-      <div class="resource-block">
-        <div class="center resource">
-          <i class="material-icons">build</i>
-          <p class="resource-name">{% trans "Educator Kits" %}</p>
-          <p class="light center">
-            {% blocktrans %}
-            There are numerous watershed-related education kits available for
-            two-week checkout, at no charge, through the OSU Extension Service,
-            Benton County office.
-
-            {% endblocktrans %}
-          </p>
-        </div>
-      </div>
-    </a>
     <a class="resource-link"href="http://www.pacname.org/oregon-coast-education-program/" target="_blank">
       <div class="resource-block">
         <div class="center resource">
@@ -232,24 +216,6 @@
         </div>
       </div>
     </a>
-    {% if perms.streamwebs.is_super_admin %}
-      <a class="resource-link"href="{% url 'streamwebs:resources-upload' %}">
-        <div class="resource-block">
-          <div class="center resource">
-            <i class="material-icons">file_upload</i>
-            <p class="resource-name">{% trans "Upload a New Resource" %}</p>
-            <p class="light center">
-              {% blocktrans %}
-              Streamwebs has education kits available for check-out at no charge. These
-              kits can be checked out by teachers, watershed educators, or other
-              non-profit groups or organizations in Oregon. Kits are available for
-              pick-up in Corvallis or Newport.
-              {% endblocktrans %}
-            </p>
-          </div>
-        </div>
-      </a>
-    {% endif %}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #649 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Removed Educator Kits
- [X] Removed Upload resource

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Go to resource page
2. See that "upload a new resource" button is gone (must be admin)
3. See educator kits button is gone

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ make test
[... test output ...]
```

@osuosl/devs
