### PR TITLE
Add Sentry.io reporting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ django-recaptcha==1.3.0
 django-queryset-csv==1.0.0
 requests==2.13.0
 dj-static==0.0.6
+contextlib2==0.5.5
+raven==6.5.0

--- a/streamwebs_frontend/streamwebs_frontend/settings.py.dist
+++ b/streamwebs_frontend/streamwebs_frontend/settings.py.dist
@@ -16,6 +16,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 import os
 from django.utils.translation import ugettext_lazy as _
 import sys
+import raven
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -63,6 +64,7 @@ DEFAULT_FROM_EMAIL = 'testing@streamwebs.org'
 # Application definition
 
 INSTALLED_APPS = [
+    'raven.contrib.django.raven_compat',
     'streamwebs',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -180,3 +182,14 @@ LANGUAGES = [
     ('ru', 'Русский'),
     ('de', 'Deutsch'),
 ]
+
+# Sentry.io configuration
+RAVEN_CONFIG = {
+    # Add your client DSN here if you want to send reports to sentry.io
+    'dsn': '',
+    # Public DSN
+    'public_dsn': '',
+    # If you are using git, you can also automatically configure the
+    # release based on the git info.
+    'release': raven.fetch_git_sha(os.path.abspath(os.path.join(BASE_DIR,os.pardir))),
+}


### PR DESCRIPTION
This adds support for https://sentry.io so that we can manage our application
errors in a more sane fashion. For it to actually work, you need to setup
projects on an account which we'll do on the OSL side. But for general
development this doesn't require anything.

You will need to rebuild your web docker image to test and use this since we
import the raven (Sentry's python library) in settings.py.

This resolves partially #652 