### PR TITLE
Edge pages now display gallery and datasheets, drop downs work

### DIFF
--- a/streamwebs_frontend/streamwebs/static/streamwebs/js/site_detail.js
+++ b/streamwebs_frontend/streamwebs/static/streamwebs/js/site_detail.js
@@ -137,10 +137,29 @@ function filter_gallery(page) {
 
 
 function get_url_params() {
-    var url = new URL(window.location.href);
-    datasheet_param = url.searchParams.get('datasheet');
-    gallery_param = url.searchParams.get('gallery');
+    // Microsoft edge refuses to support modern web standards.
+    // So URL.searchParams is reimplemented here.
 
+    datasheet_param = gallery_param = null;
+    var url = window.location.href;
+    queryString = url.split("?")[1];
+    if(queryString != null)
+    {
+      parameters = queryString.split("&");
+      searchParams = {};
+      for (var i = 0; i < parameters.length; i ++)
+      {
+        param = parameters[i];
+
+        key = param.split("=")[0];
+        value = param.split("=")[1];
+
+        searchParams[key] = value;
+      }
+      
+      datasheet_param = searchParams['datasheet'];
+      gallery_param = searchParams['gallery'];
+    }
     datasheet_page = (datasheet_param != null ? datasheet_param : datasheet_page);
     gallery_page = (gallery_param != null ? gallery_param : gallery_page);
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #645 #648

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Edge Datasheets and galleries display correctly
- [X] Add Datasheet/ Export/ Add Gallery item drop downs now work in Edge

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Load up Edge
2. Go to Site Detail, logged in as admin
3. See Gallery Items, datasheet items, drop downs working


@osuosl/devs
